### PR TITLE
fix: public wedding website 500 for logged-out visitors

### DIFF
--- a/WeddingManager.Application/Services/WeddingWebsiteService.cs
+++ b/WeddingManager.Application/Services/WeddingWebsiteService.cs
@@ -166,7 +166,7 @@ public class WeddingWebsiteService(
             eventsSection.TryGetProperty("showFromWeddingEvents", out var showEvents) &&
             showEvents.GetBoolean())
         {
-            var events = await eventRepository.GetByWeddingIdAsync(website.WeddingId);
+            var events = await eventRepository.GetByWeddingIdForPublicAsync(website.WeddingId);
             dto.Events = events.Select(e => mapper.EventToDto(e)).ToList();
         }
 

--- a/WeddingManager.Domain/Interfaces/IEventRepository.cs
+++ b/WeddingManager.Domain/Interfaces/IEventRepository.cs
@@ -18,5 +18,5 @@ public interface IEventRepository
     Task<EventGuestChangeResult> RemoveGuestFromEventAsync(Guid eventId, Guid guestId);
     Task<EventGuestBatchRemoveResultDto> RemoveGuestsFromEventAsync(Guid eventId, IReadOnlyCollection<Guid> guestIds);
     Task<IEnumerable<Event>> GetByWeddingIdAsync(Guid weddingId);
-    
+    Task<IEnumerable<Event>> GetByWeddingIdForPublicAsync(Guid weddingId);
 }

--- a/WeddingManager.Infrastructure/Repositories/EventRepository.cs
+++ b/WeddingManager.Infrastructure/Repositories/EventRepository.cs
@@ -228,6 +228,16 @@ public class EventRepository(WeddingDbContext context, IUserContextService userC
             .ToListAsync();
     }
 
+    public async Task<IEnumerable<Event>> GetByWeddingIdForPublicAsync(Guid weddingId)
+    {
+        return await context.Events
+            .AsNoTracking()
+            .Include(e => e.Guests)
+            .Where(e => e.WeddingId == weddingId)
+            .OrderBy(e => e.StartDate)
+            .ToListAsync();
+    }
+
     private async Task<EventGuestChangeResult> RemoveGuestInternalAsync(Guid eventId, Guid guestId)
     {
         var eventToUpdate = await context.Events

--- a/WeddingManager.Tests/WeddingWebsiteServiceTests.cs
+++ b/WeddingManager.Tests/WeddingWebsiteServiceTests.cs
@@ -431,7 +431,7 @@ public class WeddingWebsiteServiceTests
         var websiteRepoMock = new Mock<IWeddingWebsiteRepository>();
         websiteRepoMock.Setup(r => r.GetPublishedBySlugAsync("test-wedding")).ReturnsAsync(website);
         var eventRepoMock = new Mock<IEventRepository>();
-        eventRepoMock.Setup(r => r.GetByWeddingIdAsync(weddingId)).ReturnsAsync(events);
+        eventRepoMock.Setup(r => r.GetByWeddingIdForPublicAsync(weddingId)).ReturnsAsync(events);
         var service = CreateService(websiteRepoMock, eventRepoMock: eventRepoMock);
 
         var result = await service.GetPublicBySlugAsync("test-wedding");
@@ -455,7 +455,7 @@ public class WeddingWebsiteServiceTests
 
         Assert.True(result.IsSuccess);
         Assert.Null(result.Value!.Events);
-        eventRepoMock.Verify(r => r.GetByWeddingIdAsync(It.IsAny<Guid>()), Times.Never);
+        eventRepoMock.Verify(r => r.GetByWeddingIdForPublicAsync(It.IsAny<Guid>()), Times.Never);
     }
 
     // --- DeleteAsync ---


### PR DESCRIPTION
## Summary
- Logged-out (incognito) visitors got a 500 on `GET /api/w/{slug}` when the website's events section is enabled.
- Root cause: the public service path called `IEventRepository.GetByWeddingIdAsync`, which calls `IUserContextService.GetUserId()` — that throws when there is no authenticated user, so the exception was unhandled (500, empty body). Any logged-in user worked because the claim resolves.
- Fix: added `GetByWeddingIdForPublicAsync` (no user-context, no `UserId` filter, `AsNoTracking`) and use it in `GetPublicBySlugAsync`.

## Test plan
- [x] `dotnet build` succeeds (0 errors)
- [x] `WeddingWebsiteServiceTests` green (22/22)
- [ ] Redeploy and open a published wedding site in incognito → expect 200 (was 500)