### PR TITLE
Flow-based RSVP system (passcode-gated invitations)

### DIFF
--- a/WeddingManager.Application/Extensions/DependencyInjection.cs
+++ b/WeddingManager.Application/Extensions/DependencyInjection.cs
@@ -22,6 +22,8 @@ public static class DependencyInjection
         services.AddScoped<IWeddingWebsiteService, WeddingWebsiteService>();
         services.AddScoped<IWeddingInvitationService, WeddingInvitationService>();
         services.AddScoped<IReferralService, ReferralService>();
+        services.AddScoped<IInvitationFlowService, InvitationFlowService>();
+        services.AddScoped<IRsvpService, RsvpService>();
 
         // Register Mapperly mapper as singleton (it's stateless)
         services.AddSingleton<ApplicationMapper>();

--- a/WeddingManager.Application/Mappings/ApplicationMapper.cs
+++ b/WeddingManager.Application/Mappings/ApplicationMapper.cs
@@ -136,4 +136,23 @@ public partial class ApplicationMapper
     // Media mappings
     [MapProperty(nameof(Media.S3Url), nameof(MediaUploadResponseDto.Url))]
     public partial MediaUploadResponseDto MediaToDto(Media media);
+
+    // Invitation flow mappings - manual to carry response count and typed jsonb collections
+    public InvitationFlowDto InvitationFlowToDto(InvitationFlow flow, int responseCount)
+    {
+        return new InvitationFlowDto
+        {
+            Id = flow.Id,
+            WeddingId = flow.WeddingId,
+            Name = flow.Name,
+            Passcode = flow.Passcode,
+            IncludePlusOne = flow.IncludePlusOne,
+            CustomQuestions = flow.CustomQuestions,
+            EventIds = flow.EventIds,
+            CustomEvents = flow.CustomEvents,
+            ResponseCount = responseCount,
+            CreatedAt = flow.CreatedAt,
+            UpdatedAt = flow.UpdatedAt
+        };
+    }
 }

--- a/WeddingManager.Application/Services/InvitationFlowService.cs
+++ b/WeddingManager.Application/Services/InvitationFlowService.cs
@@ -1,0 +1,174 @@
+using WeddingManager.Application.Mappings;
+using WeddingManager.Domain.DTO;
+using WeddingManager.Domain.Entities;
+using WeddingManager.Domain.Interfaces;
+using WeddingManager.Domain.Models;
+
+namespace WeddingManager.Application.Services;
+
+public class InvitationFlowService(
+    IInvitationFlowRepository flowRepository,
+    IRsvpResponseRepository responseRepository,
+    IEventRepository eventRepository,
+    ApplicationMapper mapper) : IInvitationFlowService
+{
+    public async Task<Result<IEnumerable<InvitationFlowDto>>> GetByWeddingIdAsync(Guid weddingId)
+    {
+        var flows = (await flowRepository.GetByWeddingIdAsync(weddingId)).ToList();
+        var counts = await responseRepository.GetCountsByWeddingAsync(weddingId);
+        var dtos = flows.Select(f => mapper.InvitationFlowToDto(f, counts.GetValueOrDefault(f.Id)));
+        return Result<IEnumerable<InvitationFlowDto>>.Ok(dtos);
+    }
+
+    public async Task<Result<InvitationFlowDto>> CreateAsync(Guid weddingId, CreateInvitationFlowRequestDto requestDto)
+    {
+        var passcode = NormalizePasscode(requestDto.Passcode);
+
+        var validation = InvitationFlowValidation.ValidateInput(
+            requestDto.Name, passcode, requestDto.CustomQuestions, requestDto.CustomEvents);
+        if (!validation.IsSuccess)
+            return Result<InvitationFlowDto>.Fail(validation.Errors);
+
+        var existing = (await flowRepository.GetByWeddingIdAsync(weddingId)).ToList();
+        var exclusivity = ValidateExclusivity(existing, editingFlowId: null, passcode);
+        if (!exclusivity.IsSuccess)
+            return Result<InvitationFlowDto>.Fail(exclusivity.Errors);
+
+        var eventValidation = await ValidateEventIdsAsync(weddingId, requestDto.EventIds);
+        if (!eventValidation.IsSuccess)
+            return Result<InvitationFlowDto>.Fail(eventValidation.Errors);
+
+        var flow = new InvitationFlow
+        {
+            Id = Guid.NewGuid(),
+            WeddingId = weddingId,
+            Name = requestDto.Name.Trim(),
+            Passcode = passcode,
+            IncludePlusOne = requestDto.IncludePlusOne,
+            CustomQuestions = NormalizeQuestions(requestDto.CustomQuestions),
+            EventIds = requestDto.EventIds.Distinct().ToList(),
+            CustomEvents = NormalizeCustomEvents(requestDto.CustomEvents),
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        await flowRepository.AddAsync(flow);
+        return Result<InvitationFlowDto>.Ok(mapper.InvitationFlowToDto(flow, 0));
+    }
+
+    public async Task<Result<InvitationFlowDto>> UpdateAsync(
+        Guid weddingId, Guid flowId, UpdateInvitationFlowRequestDto requestDto)
+    {
+        var flow = await flowRepository.GetByIdAsync(flowId);
+        if (flow == null || flow.WeddingId != weddingId)
+            return Result<InvitationFlowDto>.Fail(new Error(ErrorCodes.NotFound, "Invitation flow not found"));
+
+        var passcode = NormalizePasscode(requestDto.Passcode);
+
+        var validation = InvitationFlowValidation.ValidateInput(
+            requestDto.Name, passcode, requestDto.CustomQuestions, requestDto.CustomEvents);
+        if (!validation.IsSuccess)
+            return Result<InvitationFlowDto>.Fail(validation.Errors);
+
+        var existing = (await flowRepository.GetByWeddingIdAsync(weddingId)).ToList();
+        var exclusivity = ValidateExclusivity(existing, editingFlowId: flowId, passcode);
+        if (!exclusivity.IsSuccess)
+            return Result<InvitationFlowDto>.Fail(exclusivity.Errors);
+
+        var eventValidation = await ValidateEventIdsAsync(weddingId, requestDto.EventIds);
+        if (!eventValidation.IsSuccess)
+            return Result<InvitationFlowDto>.Fail(eventValidation.Errors);
+
+        flow.Name = requestDto.Name.Trim();
+        flow.Passcode = passcode;
+        flow.IncludePlusOne = requestDto.IncludePlusOne;
+        flow.CustomQuestions = NormalizeQuestions(requestDto.CustomQuestions);
+        flow.EventIds = requestDto.EventIds.Distinct().ToList();
+        flow.CustomEvents = NormalizeCustomEvents(requestDto.CustomEvents);
+        flow.UpdatedAt = DateTime.UtcNow;
+
+        await flowRepository.UpdateAsync(flow);
+        var count = await responseRepository.CountByFlowAsync(flowId);
+        return Result<InvitationFlowDto>.Ok(mapper.InvitationFlowToDto(flow, count));
+    }
+
+    public async Task<Result> DeleteAsync(Guid weddingId, Guid flowId, bool force)
+    {
+        var flow = await flowRepository.GetByIdAsync(flowId);
+        if (flow == null || flow.WeddingId != weddingId)
+            return Result.Fail(new Error(ErrorCodes.NotFound, "Invitation flow not found"));
+
+        if (!force)
+        {
+            var count = await responseRepository.CountByFlowAsync(flowId);
+            if (count > 0)
+                return Result.Fail(new Error(ErrorCodes.Conflict,
+                    $"Flow has {count} response(s). Pass force=true to delete it and its responses."));
+        }
+
+        await flowRepository.DeleteAsync(flowId);
+        return Result.Ok();
+    }
+
+    // Either N passcoded flows, or exactly one open (no-passcode) flow.
+    private static Result ValidateExclusivity(List<InvitationFlow> existing, Guid? editingFlowId, string? passcode)
+    {
+        var others = existing.Where(f => f.Id != editingFlowId).ToList();
+
+        if (passcode == null)
+        {
+            // An open flow must be the only flow for the wedding.
+            if (others.Count > 0)
+                return Result.Fail(new Error(ErrorCodes.Conflict,
+                    "An open (no-passcode) flow must be the only flow. Remove the other flows or add a passcode."));
+            return Result.Ok();
+        }
+
+        // Passcoded flow: no open flow may coexist, and the passcode must be unique.
+        if (others.Any(f => f.Passcode == null))
+            return Result.Fail(new Error(ErrorCodes.Conflict,
+                "This wedding has an open flow. Remove it before adding passcode-protected flows."));
+
+        if (others.Any(f => string.Equals(f.Passcode, passcode, StringComparison.Ordinal)))
+            return Result.Fail(new Error(ErrorCodes.Conflict, "Another flow already uses this passcode."));
+
+        return Result.Ok();
+    }
+
+    private async Task<Result> ValidateEventIdsAsync(Guid weddingId, List<Guid> eventIds)
+    {
+        if (eventIds.Count == 0)
+            return Result.Ok();
+
+        var weddingEventIds = (await eventRepository.GetByWeddingIdUnscopedAsync(weddingId))
+            .Select(e => e.Id)
+            .ToHashSet();
+
+        return eventIds.All(weddingEventIds.Contains)
+            ? Result.Ok()
+            : Result.Fail(new Error(ErrorCodes.Validation, "One or more selected events do not belong to this wedding."));
+    }
+
+    private static string? NormalizePasscode(string? passcode) =>
+        string.IsNullOrWhiteSpace(passcode) ? null : passcode.Trim();
+
+    private static List<QuestionDefinition> NormalizeQuestions(List<QuestionDefinition> questions)
+    {
+        foreach (var q in questions)
+        {
+            if (q.Id == Guid.Empty) q.Id = Guid.NewGuid();
+            q.Label = q.Label.Trim();
+        }
+        return questions;
+    }
+
+    private static List<CustomEventDefinition> NormalizeCustomEvents(List<CustomEventDefinition> events)
+    {
+        foreach (var e in events)
+        {
+            if (e.Id == Guid.Empty) e.Id = Guid.NewGuid();
+            e.Name = e.Name.Trim();
+        }
+        return events;
+    }
+}

--- a/WeddingManager.Application/Services/InvitationFlowValidation.cs
+++ b/WeddingManager.Application/Services/InvitationFlowValidation.cs
@@ -1,0 +1,55 @@
+using WeddingManager.Domain.Enums;
+using WeddingManager.Domain.Models;
+
+namespace WeddingManager.Application.Services;
+
+public static class InvitationFlowValidation
+{
+    public static Result ValidateInput(
+        string name,
+        string? passcode,
+        List<QuestionDefinition> questions,
+        List<CustomEventDefinition> customEvents)
+    {
+        var errors = new List<Error>();
+
+        if (string.IsNullOrWhiteSpace(name))
+            errors.Add(new Error(ErrorCodes.Validation, "Flow name is required"));
+        else if (name.Length > 100)
+            errors.Add(new Error(ErrorCodes.Validation, "Flow name must be 100 characters or fewer"));
+
+        if (passcode != null)
+        {
+            if (string.IsNullOrWhiteSpace(passcode))
+                errors.Add(new Error(ErrorCodes.Validation, "Passcode cannot be blank; omit it for an open flow"));
+            else if (passcode.Length > 50)
+                errors.Add(new Error(ErrorCodes.Validation, "Passcode must be 50 characters or fewer"));
+        }
+
+        foreach (var q in questions)
+        {
+            if (string.IsNullOrWhiteSpace(q.Label))
+            {
+                errors.Add(new Error(ErrorCodes.Validation, "Every custom question needs a label"));
+                continue;
+            }
+
+            var needsOptions = q.Type is RsvpQuestionType.SingleChoice or RsvpQuestionType.MultiChoice;
+            var hasOptions = q.Options is { Count: > 0 };
+            if (needsOptions && !hasOptions)
+                errors.Add(new Error(ErrorCodes.Validation, $"Question \"{q.Label}\" needs at least one option"));
+            if (!needsOptions && hasOptions)
+                errors.Add(new Error(ErrorCodes.Validation, $"Question \"{q.Label}\" cannot have options for its type"));
+            if (needsOptions && q.Options!.Any(string.IsNullOrWhiteSpace))
+                errors.Add(new Error(ErrorCodes.Validation, $"Question \"{q.Label}\" has a blank option"));
+        }
+
+        foreach (var ce in customEvents)
+        {
+            if (string.IsNullOrWhiteSpace(ce.Name))
+                errors.Add(new Error(ErrorCodes.Validation, "Every custom event needs a name"));
+        }
+
+        return errors.Count > 0 ? Result.Fail(errors) : Result.Ok();
+    }
+}

--- a/WeddingManager.Application/Services/RsvpService.cs
+++ b/WeddingManager.Application/Services/RsvpService.cs
@@ -1,0 +1,258 @@
+using System.Text.Json;
+using WeddingManager.Domain.DTO;
+using WeddingManager.Domain.Entities;
+using WeddingManager.Domain.Enums;
+using WeddingManager.Domain.Interfaces;
+using WeddingManager.Domain.Models;
+
+namespace WeddingManager.Application.Services;
+
+public class RsvpService(
+    IWeddingRepository weddingRepository,
+    IInvitationFlowRepository flowRepository,
+    IRsvpResponseRepository responseRepository,
+    IGuestRepository guestRepository,
+    IEventRepository eventRepository) : IRsvpService
+{
+    public async Task<Result<RsvpFlowStateDto>> GetFlowStateAsync(string weddingSlugOrId)
+    {
+        var wedding = await weddingRepository.GetByIdOrSlugAsync(weddingSlugOrId);
+        if (wedding == null)
+            return Result<RsvpFlowStateDto>.Fail(new Error(ErrorCodes.NotFound, "Wedding not found"));
+
+        var flows = (await flowRepository.GetByWeddingIdAsync(wedding.Id)).ToList();
+        if (flows.Count == 0)
+            return Result<RsvpFlowStateDto>.Ok(new RsvpFlowStateDto { HasFlows = false });
+
+        var openFlow = flows.FirstOrDefault(f => f.Passcode == null);
+        if (openFlow != null)
+        {
+            var dto = await BuildPublicFlowAsync(wedding.Id, openFlow);
+            return Result<RsvpFlowStateDto>.Ok(new RsvpFlowStateDto
+            {
+                HasFlows = true,
+                RequiresPasscode = false,
+                Flow = dto
+            });
+        }
+
+        return Result<RsvpFlowStateDto>.Ok(new RsvpFlowStateDto
+        {
+            HasFlows = true,
+            RequiresPasscode = true
+        });
+    }
+
+    public async Task<Result<RsvpFlowPublicDto>> UnlockAsync(string weddingSlugOrId, string passcode)
+    {
+        var wedding = await weddingRepository.GetByIdOrSlugAsync(weddingSlugOrId);
+        if (wedding == null)
+            return Result<RsvpFlowPublicDto>.Fail(new Error(ErrorCodes.NotFound, "Wedding not found"));
+
+        if (string.IsNullOrWhiteSpace(passcode))
+            return Result<RsvpFlowPublicDto>.Fail(new Error(ErrorCodes.Unauthorized, "Invalid passcode"));
+
+        var flow = await flowRepository.GetByPasscodeAsync(wedding.Id, passcode.Trim());
+        if (flow == null)
+            return Result<RsvpFlowPublicDto>.Fail(new Error(ErrorCodes.Unauthorized, "Invalid passcode"));
+
+        var dto = await BuildPublicFlowAsync(wedding.Id, flow);
+        return Result<RsvpFlowPublicDto>.Ok(dto);
+    }
+
+    public async Task<Result<RsvpSubmitResultDto>> SubmitAsync(
+        string weddingSlugOrId, Guid flowId, RsvpFlowSubmitRequestDto requestDto)
+    {
+        var wedding = await weddingRepository.GetByIdOrSlugAsync(weddingSlugOrId);
+        if (wedding == null)
+            return Result<RsvpSubmitResultDto>.Fail(new Error(ErrorCodes.NotFound, "Wedding not found"));
+
+        var flow = await flowRepository.GetByIdAsync(flowId);
+        if (flow == null || flow.WeddingId != wedding.Id)
+            return Result<RsvpSubmitResultDto>.Fail(new Error(ErrorCodes.NotFound, "Invitation flow not found"));
+
+        var validEventIds = await GetValidEventIdsAsync(wedding.Id, flow);
+        var validation = RsvpSubmissionValidation.Validate(flow, requestDto, validEventIds);
+        if (!validation.IsSuccess)
+            return Result<RsvpSubmitResultDto>.Fail(validation.Errors);
+
+        var name = requestDto.Name.Trim();
+        var surname = requestDto.Surname.Trim();
+        var email = requestDto.Email.Trim();
+
+        var duplicate = await guestRepository.FindByDedupeKeyAsync(wedding.Id, email, name, surname);
+        if (duplicate != null)
+            return Result<RsvpSubmitResultDto>.Fail(new Error(ErrorCodes.Conflict,
+                "An RSVP with this name and email already exists for this wedding."));
+
+        var attendingEventIds = requestDto.Status == RsvpResponseStatus.Attending
+            ? requestDto.AttendingEventIds.Where(validEventIds.Contains).Distinct().ToList()
+            : new List<Guid>();
+
+        var guestStatus = requestDto.Status == RsvpResponseStatus.Attending ? RsvpStatus.Accepted : RsvpStatus.Declined;
+
+        var mainGuest = new Guest
+        {
+            Id = Guid.NewGuid(),
+            WeddingId = wedding.Id,
+            Name = name,
+            Surname = surname,
+            Email = email,
+            Dietary = string.IsNullOrWhiteSpace(requestDto.Dietary) ? null : requestDto.Dietary.Trim(),
+            RsvpStatus = guestStatus
+        };
+
+        var guests = new List<Guest> { mainGuest };
+        var responses = new List<RsvpResponse>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                WeddingId = wedding.Id,
+                InvitationFlowId = flow.Id,
+                GuestId = mainGuest.Id,
+                Status = requestDto.Status,
+                AttendingEventIds = attendingEventIds,
+                CustomAnswers = JsonSerializer.Serialize(requestDto.CustomAnswers, RsvpJson.Options),
+                SubmittedAt = DateTime.UtcNow
+            }
+        };
+
+        Guid? plusOneGuestId = null;
+        if (requestDto is { PlusOneAttending: true } && flow.IncludePlusOne && !string.IsNullOrWhiteSpace(requestDto.PlusOneName))
+        {
+            var plusOne = new Guest
+            {
+                Id = Guid.NewGuid(),
+                WeddingId = wedding.Id,
+                Name = requestDto.PlusOneName.Trim(),
+                Surname = null,
+                Email = email,
+                Dietary = string.IsNullOrWhiteSpace(requestDto.PlusOneDietary) ? null : requestDto.PlusOneDietary.Trim(),
+                RsvpStatus = RsvpStatus.Accepted,
+                PlusOneOfGuestId = mainGuest.Id
+            };
+            plusOneGuestId = plusOne.Id;
+            guests.Add(plusOne);
+            responses.Add(new RsvpResponse
+            {
+                Id = Guid.NewGuid(),
+                WeddingId = wedding.Id,
+                InvitationFlowId = flow.Id,
+                GuestId = plusOne.Id,
+                Status = RsvpResponseStatus.Attending,
+                AttendingEventIds = attendingEventIds,
+                CustomAnswers = "{}",
+                SubmittedAt = DateTime.UtcNow
+            });
+        }
+
+        var saved = await responseRepository.SubmitAsync(guests, responses);
+        if (!saved)
+            return Result<RsvpSubmitResultDto>.Fail(new Error(ErrorCodes.Conflict,
+                "An RSVP with this name and email already exists for this wedding."));
+
+        return Result<RsvpSubmitResultDto>.Ok(new RsvpSubmitResultDto
+        {
+            ResponseId = responses[0].Id,
+            GuestId = mainGuest.Id,
+            PlusOneGuestId = plusOneGuestId
+        });
+    }
+
+    public async Task<Result<IEnumerable<RsvpResponseDto>>> GetResponsesAsync(Guid weddingId, Guid? flowId)
+    {
+        var responses = (await responseRepository.GetByWeddingIdAsync(weddingId, flowId)).ToList();
+        var events = (await eventRepository.GetByWeddingIdUnscopedAsync(weddingId)).ToList();
+        var flows = (await flowRepository.GetByWeddingIdAsync(weddingId)).ToList();
+
+        var eventNames = events.ToDictionary(e => e.Id, e => e.Name);
+        var customEventNames = flows
+            .SelectMany(f => f.CustomEvents)
+            .GroupBy(ce => ce.Id)
+            .ToDictionary(g => g.Key, g => g.First().Name);
+
+        var dtos = responses.Select(r =>
+        {
+            var flow = flows.FirstOrDefault(f => f.Id == r.InvitationFlowId);
+            return new RsvpResponseDto
+            {
+                Id = r.Id,
+                InvitationFlowId = r.InvitationFlowId,
+                FlowName = flow?.Name ?? string.Empty,
+                GuestId = r.GuestId,
+                Name = r.Guest.Name,
+                Surname = r.Guest.Surname,
+                Email = r.Guest.Email,
+                Dietary = r.Guest.Dietary,
+                Status = r.Status,
+                AttendingEventIds = r.AttendingEventIds,
+                AttendingEventNames = r.AttendingEventIds
+                    .Select(id => eventNames.GetValueOrDefault(id)
+                        ?? customEventNames.GetValueOrDefault(id)
+                        ?? "(deleted event)")
+                    .ToList(),
+                CustomAnswers = DeserializeAnswers(r.CustomAnswers),
+                IsPlusOne = r.Guest.PlusOneOfGuestId != null,
+                PlusOneOfGuestId = r.Guest.PlusOneOfGuestId,
+                SubmittedAt = r.SubmittedAt
+            };
+        });
+
+        return Result<IEnumerable<RsvpResponseDto>>.Ok(dtos);
+    }
+
+    private async Task<HashSet<Guid>> GetValidEventIdsAsync(Guid weddingId, InvitationFlow flow)
+    {
+        var realEventIds = (await eventRepository.GetByWeddingIdUnscopedAsync(weddingId))
+            .Select(e => e.Id)
+            .ToHashSet();
+        var valid = flow.EventIds.Where(realEventIds.Contains).ToHashSet();
+        foreach (var ce in flow.CustomEvents)
+            valid.Add(ce.Id);
+        return valid;
+    }
+
+    private async Task<RsvpFlowPublicDto> BuildPublicFlowAsync(Guid weddingId, InvitationFlow flow)
+    {
+        var realEvents = (await eventRepository.GetByWeddingIdUnscopedAsync(weddingId))
+            .Where(e => flow.EventIds.Contains(e.Id))
+            .Select(e => new RsvpEventOptionDto
+            {
+                Id = e.Id,
+                Name = e.Name,
+                StartDate = e.StartDate,
+                Location = e.Location
+            });
+
+        var customEvents = flow.CustomEvents.Select(ce => new RsvpEventOptionDto
+        {
+            Id = ce.Id,
+            Name = ce.Name,
+            StartDate = ce.StartDate,
+            Location = ce.Location
+        });
+
+        var allEvents = realEvents
+            .Concat(customEvents)
+            .OrderBy(e => e.StartDate ?? DateTime.MaxValue)
+            .ToList();
+
+        return new RsvpFlowPublicDto
+        {
+            FlowId = flow.Id,
+            WeddingId = weddingId,
+            IncludePlusOne = flow.IncludePlusOne,
+            Questions = flow.CustomQuestions,
+            Events = allEvents
+        };
+    }
+
+    private static Dictionary<string, JsonElement> DeserializeAnswers(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json) || json == "{}")
+            return new Dictionary<string, JsonElement>();
+        return JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json, RsvpJson.Options)
+            ?? new Dictionary<string, JsonElement>();
+    }
+}

--- a/WeddingManager.Application/Services/RsvpSubmissionValidation.cs
+++ b/WeddingManager.Application/Services/RsvpSubmissionValidation.cs
@@ -36,7 +36,9 @@ public static class RsvpSubmissionValidation
                 errors.Add(new Error(ErrorCodes.Validation, "Plus-one name is required when bringing a plus-one"));
         }
 
-        ValidateCustomAnswers(flow, dto, errors);
+        // A guest who declines answers no custom questions.
+        if (dto.Status == RsvpResponseStatus.Attending)
+            ValidateCustomAnswers(flow, dto, errors);
 
         return errors.Count > 0 ? Result.Fail(errors) : Result.Ok();
     }

--- a/WeddingManager.Application/Services/RsvpSubmissionValidation.cs
+++ b/WeddingManager.Application/Services/RsvpSubmissionValidation.cs
@@ -1,0 +1,96 @@
+using System.Text.Json;
+using WeddingManager.Domain.DTO;
+using WeddingManager.Domain.Entities;
+using WeddingManager.Domain.Enums;
+using WeddingManager.Domain.Models;
+
+namespace WeddingManager.Application.Services;
+
+public static class RsvpSubmissionValidation
+{
+    public static Result Validate(InvitationFlow flow, RsvpFlowSubmitRequestDto dto, ISet<Guid> validEventIds)
+    {
+        var errors = new List<Error>();
+
+        if (string.IsNullOrWhiteSpace(dto.Name))
+            errors.Add(new Error(ErrorCodes.Validation, "Name is required"));
+        if (string.IsNullOrWhiteSpace(dto.Surname))
+            errors.Add(new Error(ErrorCodes.Validation, "Surname is required"));
+        if (string.IsNullOrWhiteSpace(dto.Email) || !GuestValidation.IsValidEmail(dto.Email))
+            errors.Add(new Error(ErrorCodes.Validation, "A valid email is required"));
+
+        if (dto.Status == RsvpResponseStatus.Attending)
+        {
+            foreach (var id in dto.AttendingEventIds)
+            {
+                if (!validEventIds.Contains(id))
+                    errors.Add(new Error(ErrorCodes.Validation, "An selected event is not part of this invitation"));
+            }
+        }
+
+        if (dto.PlusOneAttending)
+        {
+            if (!flow.IncludePlusOne)
+                errors.Add(new Error(ErrorCodes.Validation, "This invitation does not allow a plus-one"));
+            else if (string.IsNullOrWhiteSpace(dto.PlusOneName))
+                errors.Add(new Error(ErrorCodes.Validation, "Plus-one name is required when bringing a plus-one"));
+        }
+
+        ValidateCustomAnswers(flow, dto, errors);
+
+        return errors.Count > 0 ? Result.Fail(errors) : Result.Ok();
+    }
+
+    private static void ValidateCustomAnswers(InvitationFlow flow, RsvpFlowSubmitRequestDto dto, List<Error> errors)
+    {
+        foreach (var question in flow.CustomQuestions)
+        {
+            var key = question.Id.ToString();
+            var present = dto.CustomAnswers.TryGetValue(key, out var answer) && !IsEmpty(answer);
+
+            if (!present)
+            {
+                if (question.Required)
+                    errors.Add(new Error(ErrorCodes.Validation, $"\"{question.Label}\" is required"));
+                continue;
+            }
+
+            switch (question.Type)
+            {
+                case RsvpQuestionType.YesNo:
+                    if (answer.ValueKind is not (JsonValueKind.True or JsonValueKind.False))
+                        errors.Add(new Error(ErrorCodes.Validation, $"\"{question.Label}\" must be yes or no"));
+                    break;
+
+                case RsvpQuestionType.FreeText:
+                    if (answer.ValueKind != JsonValueKind.String)
+                        errors.Add(new Error(ErrorCodes.Validation, $"\"{question.Label}\" must be text"));
+                    break;
+
+                case RsvpQuestionType.SingleChoice:
+                    if (answer.ValueKind != JsonValueKind.String ||
+                        !(question.Options?.Contains(answer.GetString()!) ?? false))
+                        errors.Add(new Error(ErrorCodes.Validation, $"\"{question.Label}\" has an invalid choice"));
+                    break;
+
+                case RsvpQuestionType.MultiChoice:
+                    if (answer.ValueKind != JsonValueKind.Array ||
+                        answer.EnumerateArray().Any(v =>
+                            v.ValueKind != JsonValueKind.String ||
+                            !(question.Options?.Contains(v.GetString()!) ?? false)))
+                        errors.Add(new Error(ErrorCodes.Validation, $"\"{question.Label}\" has an invalid selection"));
+                    break;
+            }
+        }
+    }
+
+    private static bool IsEmpty(JsonElement value) =>
+        value.ValueKind switch
+        {
+            JsonValueKind.Null => true,
+            JsonValueKind.Undefined => true,
+            JsonValueKind.String => string.IsNullOrWhiteSpace(value.GetString()),
+            JsonValueKind.Array => value.GetArrayLength() == 0,
+            _ => false
+        };
+}

--- a/WeddingManager.Domain/DTO/CreateInvitationFlowRequestDto.cs
+++ b/WeddingManager.Domain/DTO/CreateInvitationFlowRequestDto.cs
@@ -1,0 +1,13 @@
+using WeddingManager.Domain.Models;
+
+namespace WeddingManager.Domain.DTO;
+
+public class CreateInvitationFlowRequestDto
+{
+    public string Name { get; set; } = string.Empty;
+    public string? Passcode { get; set; }
+    public bool IncludePlusOne { get; set; }
+    public List<QuestionDefinition> CustomQuestions { get; set; } = new();
+    public List<Guid> EventIds { get; set; } = new();
+    public List<CustomEventDefinition> CustomEvents { get; set; } = new();
+}

--- a/WeddingManager.Domain/DTO/GuestDto.cs
+++ b/WeddingManager.Domain/DTO/GuestDto.cs
@@ -6,9 +6,12 @@ public class GuestDto
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;
+    public string? Surname { get; set; }
     public string Email { get; set; } = string.Empty;
+    public string? Dietary { get; set; }
     public RsvpStatus RsvpStatus { get; set; }
     public string PreferredLanguage { get; set; } = "en";
     public DateTime? InvitationSentAt { get; set; }
     public Guid WeddingId { get; set; }
+    public Guid? PlusOneOfGuestId { get; set; }
 }

--- a/WeddingManager.Domain/DTO/InvitationFlowDto.cs
+++ b/WeddingManager.Domain/DTO/InvitationFlowDto.cs
@@ -1,0 +1,18 @@
+using WeddingManager.Domain.Models;
+
+namespace WeddingManager.Domain.DTO;
+
+public class InvitationFlowDto
+{
+    public Guid Id { get; set; }
+    public Guid WeddingId { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string? Passcode { get; set; }
+    public bool IncludePlusOne { get; set; }
+    public List<QuestionDefinition> CustomQuestions { get; set; } = new();
+    public List<Guid> EventIds { get; set; } = new();
+    public List<CustomEventDefinition> CustomEvents { get; set; } = new();
+    public int ResponseCount { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}

--- a/WeddingManager.Domain/DTO/RsvpEventOptionDto.cs
+++ b/WeddingManager.Domain/DTO/RsvpEventOptionDto.cs
@@ -1,0 +1,10 @@
+namespace WeddingManager.Domain.DTO;
+
+/// <summary>An event a guest can pick in an RSVP flow — a real Event or a flow-local custom one.</summary>
+public class RsvpEventOptionDto
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public DateTime? StartDate { get; set; }
+    public string? Location { get; set; }
+}

--- a/WeddingManager.Domain/DTO/RsvpFlowPublicDto.cs
+++ b/WeddingManager.Domain/DTO/RsvpFlowPublicDto.cs
@@ -1,0 +1,15 @@
+using WeddingManager.Domain.Models;
+
+namespace WeddingManager.Domain.DTO;
+
+/// <summary>What a guest sees once a flow is unlocked. Never exposes passcode or planner label.</summary>
+public class RsvpFlowPublicDto
+{
+    public Guid FlowId { get; set; }
+    public Guid WeddingId { get; set; }
+    public bool IncludePlusOne { get; set; }
+    public List<QuestionDefinition> Questions { get; set; } = new();
+
+    /// <summary>Merged real + custom events, sorted by start date.</summary>
+    public List<RsvpEventOptionDto> Events { get; set; } = new();
+}

--- a/WeddingManager.Domain/DTO/RsvpFlowStateDto.cs
+++ b/WeddingManager.Domain/DTO/RsvpFlowStateDto.cs
@@ -1,0 +1,12 @@
+namespace WeddingManager.Domain.DTO;
+
+/// <summary>
+/// Initial public state for a wedding's RSVP. If exactly one open (no-passcode) flow exists,
+/// <see cref="Flow"/> is populated directly; otherwise the guest must unlock with a passcode.
+/// </summary>
+public class RsvpFlowStateDto
+{
+    public bool HasFlows { get; set; }
+    public bool RequiresPasscode { get; set; }
+    public RsvpFlowPublicDto? Flow { get; set; }
+}

--- a/WeddingManager.Domain/DTO/RsvpFlowSubmitRequestDto.cs
+++ b/WeddingManager.Domain/DTO/RsvpFlowSubmitRequestDto.cs
@@ -1,0 +1,22 @@
+using System.Text.Json;
+using WeddingManager.Domain.Enums;
+
+namespace WeddingManager.Domain.DTO;
+
+public class RsvpFlowSubmitRequestDto
+{
+    public string Name { get; set; } = string.Empty;
+    public string Surname { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string? Dietary { get; set; }
+
+    public RsvpResponseStatus Status { get; set; }
+    public List<Guid> AttendingEventIds { get; set; } = new();
+
+    public bool PlusOneAttending { get; set; }
+    public string? PlusOneName { get; set; }
+    public string? PlusOneDietary { get; set; }
+
+    /// <summary>Keyed by question id. Value shape depends on question type.</summary>
+    public Dictionary<string, JsonElement> CustomAnswers { get; set; } = new();
+}

--- a/WeddingManager.Domain/DTO/RsvpResponseDto.cs
+++ b/WeddingManager.Domain/DTO/RsvpResponseDto.cs
@@ -1,0 +1,23 @@
+using System.Text.Json;
+using WeddingManager.Domain.Enums;
+
+namespace WeddingManager.Domain.DTO;
+
+public class RsvpResponseDto
+{
+    public Guid Id { get; set; }
+    public Guid InvitationFlowId { get; set; }
+    public string FlowName { get; set; } = string.Empty;
+    public Guid GuestId { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string? Surname { get; set; }
+    public string Email { get; set; } = string.Empty;
+    public string? Dietary { get; set; }
+    public RsvpResponseStatus Status { get; set; }
+    public List<Guid> AttendingEventIds { get; set; } = new();
+    public List<string> AttendingEventNames { get; set; } = new();
+    public Dictionary<string, JsonElement> CustomAnswers { get; set; } = new();
+    public bool IsPlusOne { get; set; }
+    public Guid? PlusOneOfGuestId { get; set; }
+    public DateTime SubmittedAt { get; set; }
+}

--- a/WeddingManager.Domain/DTO/RsvpSubmitResultDto.cs
+++ b/WeddingManager.Domain/DTO/RsvpSubmitResultDto.cs
@@ -1,0 +1,8 @@
+namespace WeddingManager.Domain.DTO;
+
+public class RsvpSubmitResultDto
+{
+    public Guid ResponseId { get; set; }
+    public Guid GuestId { get; set; }
+    public Guid? PlusOneGuestId { get; set; }
+}

--- a/WeddingManager.Domain/DTO/RsvpUnlockRequestDto.cs
+++ b/WeddingManager.Domain/DTO/RsvpUnlockRequestDto.cs
@@ -1,0 +1,6 @@
+namespace WeddingManager.Domain.DTO;
+
+public class RsvpUnlockRequestDto
+{
+    public string Passcode { get; set; } = string.Empty;
+}

--- a/WeddingManager.Domain/DTO/UpdateInvitationFlowRequestDto.cs
+++ b/WeddingManager.Domain/DTO/UpdateInvitationFlowRequestDto.cs
@@ -1,0 +1,13 @@
+using WeddingManager.Domain.Models;
+
+namespace WeddingManager.Domain.DTO;
+
+public class UpdateInvitationFlowRequestDto
+{
+    public string Name { get; set; } = string.Empty;
+    public string? Passcode { get; set; }
+    public bool IncludePlusOne { get; set; }
+    public List<QuestionDefinition> CustomQuestions { get; set; } = new();
+    public List<Guid> EventIds { get; set; } = new();
+    public List<CustomEventDefinition> CustomEvents { get; set; } = new();
+}

--- a/WeddingManager.Domain/Entities/Guest.cs
+++ b/WeddingManager.Domain/Entities/Guest.cs
@@ -6,7 +6,9 @@ public class Guest
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;
+    public string? Surname { get; set; }
     public string Email { get; set; } = string.Empty;
+    public string? Dietary { get; set; }
     public RsvpStatus RsvpStatus { get; set; } = RsvpStatus.Pending;
     public string PreferredLanguage { get; set; } = "en";
     public string? InvitationToken { get; set; }
@@ -15,4 +17,8 @@ public class Guest
     public Guid WeddingId { get; set; }
     public Wedding Wedding { get; set; } = null!;
     public ICollection<Event> Events { get; set; } = null!;
+
+    /// <summary>When set, this guest is a plus-one of another guest.</summary>
+    public Guid? PlusOneOfGuestId { get; set; }
+    public Guest? PlusOneOf { get; set; }
 }

--- a/WeddingManager.Domain/Entities/InvitationFlow.cs
+++ b/WeddingManager.Domain/Entities/InvitationFlow.cs
@@ -1,0 +1,31 @@
+using WeddingManager.Domain.Models;
+
+namespace WeddingManager.Domain.Entities;
+
+public class InvitationFlow
+{
+    public Guid Id { get; set; }
+    public Guid WeddingId { get; set; }
+    public Wedding Wedding { get; set; } = null!;
+
+    /// <summary>Planner-facing label only ("Family", "Day-only"). Never shown to guests.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Plain text. Null = open flow (only one allowed per wedding). Unique within wedding when set.</summary>
+    public string? Passcode { get; set; }
+
+    public bool IncludePlusOne { get; set; }
+
+    public List<QuestionDefinition> CustomQuestions { get; set; } = new();
+
+    /// <summary>Ids of real <see cref="Event"/> rows this flow exposes for selection.</summary>
+    public List<Guid> EventIds { get; set; } = new();
+
+    /// <summary>Flow-local events not backed by an <see cref="Event"/> row.</summary>
+    public List<CustomEventDefinition> CustomEvents { get; set; } = new();
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+    public ICollection<RsvpResponse> Responses { get; set; } = null!;
+}

--- a/WeddingManager.Domain/Entities/RsvpResponse.cs
+++ b/WeddingManager.Domain/Entities/RsvpResponse.cs
@@ -1,0 +1,27 @@
+using WeddingManager.Domain.Enums;
+
+namespace WeddingManager.Domain.Entities;
+
+public class RsvpResponse
+{
+    public Guid Id { get; set; }
+
+    public Guid WeddingId { get; set; }
+    public Wedding Wedding { get; set; } = null!;
+
+    public Guid InvitationFlowId { get; set; }
+    public InvitationFlow InvitationFlow { get; set; } = null!;
+
+    public Guid GuestId { get; set; }
+    public Guest Guest { get; set; } = null!;
+
+    public RsvpResponseStatus Status { get; set; }
+
+    /// <summary>Subset of the flow's exposed events (real Event ids and/or flow-local custom-event ids).</summary>
+    public List<Guid> AttendingEventIds { get; set; } = new();
+
+    /// <summary>Raw jsonb object keyed by question id; heterogeneous values. Empty object for plus-ones.</summary>
+    public string CustomAnswers { get; set; } = "{}";
+
+    public DateTime SubmittedAt { get; set; } = DateTime.UtcNow;
+}

--- a/WeddingManager.Domain/Enums/RsvpQuestionType.cs
+++ b/WeddingManager.Domain/Enums/RsvpQuestionType.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace WeddingManager.Domain.Enums;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum RsvpQuestionType
+{
+    YesNo,
+    FreeText,
+    SingleChoice,
+    MultiChoice
+}

--- a/WeddingManager.Domain/Enums/RsvpResponseStatus.cs
+++ b/WeddingManager.Domain/Enums/RsvpResponseStatus.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace WeddingManager.Domain.Enums;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum RsvpResponseStatus
+{
+    Attending,
+    Declined
+}

--- a/WeddingManager.Domain/Interfaces/IEventRepository.cs
+++ b/WeddingManager.Domain/Interfaces/IEventRepository.cs
@@ -18,5 +18,7 @@ public interface IEventRepository
     Task<EventGuestChangeResult> RemoveGuestFromEventAsync(Guid eventId, Guid guestId);
     Task<EventGuestBatchRemoveResultDto> RemoveGuestsFromEventAsync(Guid eventId, IReadOnlyCollection<Guid> guestIds);
     Task<IEnumerable<Event>> GetByWeddingIdAsync(Guid weddingId);
-    
+
+    /// <summary>Events for a wedding without current-user scoping (for public RSVP rendering).</summary>
+    Task<IEnumerable<Event>> GetByWeddingIdUnscopedAsync(Guid weddingId);
 }

--- a/WeddingManager.Domain/Interfaces/IGuestRepository.cs
+++ b/WeddingManager.Domain/Interfaces/IGuestRepository.cs
@@ -8,6 +8,7 @@ public interface IGuestRepository
     Task<IEnumerable<Guest>> GetByWeddingIdAsync(Guid weddingId);
     Task<IEnumerable<Guest>> GetByIdsAsync(Guid weddingId, IEnumerable<Guid> guestIds);
     Task<Guest?> GetByEmailAsync(Guid weddingId, string email);
+    Task<Guest?> FindByDedupeKeyAsync(Guid weddingId, string email, string name, string? surname);
     Task<int> CountByWeddingIdAsync(Guid weddingId);
     Task AddAsync(Guest guest);
     Task AddRangeAsync(IEnumerable<Guest> guests);

--- a/WeddingManager.Domain/Interfaces/IInvitationFlowRepository.cs
+++ b/WeddingManager.Domain/Interfaces/IInvitationFlowRepository.cs
@@ -1,0 +1,13 @@
+using WeddingManager.Domain.Entities;
+
+namespace WeddingManager.Domain.Interfaces;
+
+public interface IInvitationFlowRepository
+{
+    Task<IEnumerable<InvitationFlow>> GetByWeddingIdAsync(Guid weddingId);
+    Task<InvitationFlow?> GetByIdAsync(Guid flowId);
+    Task<InvitationFlow?> GetByPasscodeAsync(Guid weddingId, string passcode);
+    Task AddAsync(InvitationFlow flow);
+    Task UpdateAsync(InvitationFlow flow);
+    Task DeleteAsync(Guid flowId);
+}

--- a/WeddingManager.Domain/Interfaces/IInvitationFlowService.cs
+++ b/WeddingManager.Domain/Interfaces/IInvitationFlowService.cs
@@ -1,0 +1,12 @@
+using WeddingManager.Domain.DTO;
+using WeddingManager.Domain.Models;
+
+namespace WeddingManager.Domain.Interfaces;
+
+public interface IInvitationFlowService
+{
+    Task<Result<IEnumerable<InvitationFlowDto>>> GetByWeddingIdAsync(Guid weddingId);
+    Task<Result<InvitationFlowDto>> CreateAsync(Guid weddingId, CreateInvitationFlowRequestDto requestDto);
+    Task<Result<InvitationFlowDto>> UpdateAsync(Guid weddingId, Guid flowId, UpdateInvitationFlowRequestDto requestDto);
+    Task<Result> DeleteAsync(Guid weddingId, Guid flowId, bool force);
+}

--- a/WeddingManager.Domain/Interfaces/IRsvpResponseRepository.cs
+++ b/WeddingManager.Domain/Interfaces/IRsvpResponseRepository.cs
@@ -1,0 +1,16 @@
+using WeddingManager.Domain.Entities;
+
+namespace WeddingManager.Domain.Interfaces;
+
+public interface IRsvpResponseRepository
+{
+    Task<IReadOnlyDictionary<Guid, int>> GetCountsByWeddingAsync(Guid weddingId);
+    Task<int> CountByFlowAsync(Guid flowId);
+    Task<IEnumerable<RsvpResponse>> GetByWeddingIdAsync(Guid weddingId, Guid? flowId);
+
+    /// <summary>
+    /// Persists all guests and responses for one submission in a single transaction.
+    /// Returns false if a unique-constraint (dedupe) violation occurred; rethrows other errors.
+    /// </summary>
+    Task<bool> SubmitAsync(IReadOnlyCollection<Guest> guests, IReadOnlyCollection<RsvpResponse> responses);
+}

--- a/WeddingManager.Domain/Interfaces/IRsvpService.cs
+++ b/WeddingManager.Domain/Interfaces/IRsvpService.cs
@@ -1,0 +1,14 @@
+using WeddingManager.Domain.DTO;
+using WeddingManager.Domain.Models;
+
+namespace WeddingManager.Domain.Interfaces;
+
+public interface IRsvpService
+{
+    Task<Result<RsvpFlowStateDto>> GetFlowStateAsync(string weddingSlugOrId);
+    Task<Result<RsvpFlowPublicDto>> UnlockAsync(string weddingSlugOrId, string passcode);
+    Task<Result<RsvpSubmitResultDto>> SubmitAsync(string weddingSlugOrId, Guid flowId, RsvpFlowSubmitRequestDto requestDto);
+
+    /// <summary>Couple-facing dashboard read.</summary>
+    Task<Result<IEnumerable<RsvpResponseDto>>> GetResponsesAsync(Guid weddingId, Guid? flowId);
+}

--- a/WeddingManager.Domain/Models/CustomEventDefinition.cs
+++ b/WeddingManager.Domain/Models/CustomEventDefinition.cs
@@ -1,0 +1,13 @@
+namespace WeddingManager.Domain.Models;
+
+/// <summary>
+/// A flow-local event (not backed by a real <see cref="Entities.Event"/> row), stored as jsonb.
+/// Its <see cref="Id"/> can appear in <see cref="Entities.RsvpResponse.AttendingEventIds"/>.
+/// </summary>
+public class CustomEventDefinition
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Name { get; set; } = string.Empty;
+    public DateTime? StartDate { get; set; }
+    public string? Location { get; set; }
+}

--- a/WeddingManager.Domain/Models/QuestionDefinition.cs
+++ b/WeddingManager.Domain/Models/QuestionDefinition.cs
@@ -1,0 +1,17 @@
+using WeddingManager.Domain.Enums;
+
+namespace WeddingManager.Domain.Models;
+
+/// <summary>
+/// A custom question defined on an <see cref="Entities.InvitationFlow"/>, stored as jsonb.
+/// </summary>
+public class QuestionDefinition
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public RsvpQuestionType Type { get; set; }
+    public string Label { get; set; } = string.Empty;
+    public bool Required { get; set; }
+
+    /// <summary>Choices for SingleChoice / MultiChoice; null or empty for YesNo / FreeText.</summary>
+    public List<string>? Options { get; set; }
+}

--- a/WeddingManager.Domain/Models/RsvpJson.cs
+++ b/WeddingManager.Domain/Models/RsvpJson.cs
@@ -1,0 +1,16 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace WeddingManager.Domain.Models;
+
+/// <summary>
+/// Shared System.Text.Json options for RSVP jsonb columns and DTO payloads, so the EF value
+/// converters and the service layer serialize identically (camelCase keys, string enums).
+/// </summary>
+public static class RsvpJson
+{
+    public static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter() }
+    };
+}

--- a/WeddingManager.Infrastructure/Data/Configurations/GuestEntityConfiguration.cs
+++ b/WeddingManager.Infrastructure/Data/Configurations/GuestEntityConfiguration.cs
@@ -10,7 +10,9 @@ public class GuestConfiguration : IEntityTypeConfiguration<Guest>
     {
         builder.HasKey(e => e.Id);
         builder.Property(e => e.Name).IsRequired().HasMaxLength(255);
+        builder.Property(e => e.Surname).HasMaxLength(255);
         builder.Property(e => e.Email).IsRequired().HasMaxLength(255);
+        builder.Property(e => e.Dietary);
         builder.Property(e => e.PreferredLanguage)
             .IsRequired()
             .HasMaxLength(10)
@@ -21,8 +23,10 @@ public class GuestConfiguration : IEntityTypeConfiguration<Guest>
             .IsRequired()
             .HasMaxLength(50)
             .HasConversion<string>();
-        
-        builder.HasIndex(e => new { e.WeddingId, e.Email }).IsUnique();
+
+        // Composite dedupe key is case-insensitive on email/name/surname; created as a
+        // functional unique index via raw SQL in the migration (lower(...) can't be
+        // expressed through the fluent API). The old (WeddingId, Email) index is dropped there.
         builder.HasIndex(e => e.WeddingId);
         builder.HasIndex(e => e.InvitationToken).IsUnique();
 
@@ -30,5 +34,10 @@ public class GuestConfiguration : IEntityTypeConfiguration<Guest>
             .WithMany(w => w.Guests)
             .HasForeignKey(g => g.WeddingId)
             .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(g => g.PlusOneOf)
+            .WithMany()
+            .HasForeignKey(g => g.PlusOneOfGuestId)
+            .OnDelete(DeleteBehavior.SetNull);
     }
 }

--- a/WeddingManager.Infrastructure/Data/Configurations/InvitationFlowConfiguration.cs
+++ b/WeddingManager.Infrastructure/Data/Configurations/InvitationFlowConfiguration.cs
@@ -1,0 +1,45 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using WeddingManager.Domain.Entities;
+using WeddingManager.Domain.Models;
+
+namespace WeddingManager.Infrastructure.Data.Configurations;
+
+public class InvitationFlowConfiguration : IEntityTypeConfiguration<InvitationFlow>
+{
+    public void Configure(EntityTypeBuilder<InvitationFlow> builder)
+    {
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Name).IsRequired().HasMaxLength(100);
+        builder.Property(e => e.Passcode).HasMaxLength(50);
+        builder.Property(e => e.IncludePlusOne).IsRequired();
+
+        builder.Property(e => e.CustomQuestions)
+            .HasColumnType("jsonb")
+            .HasConversion(JsonbConverters.ListConverter<QuestionDefinition>())
+            .Metadata.SetValueComparer(JsonbConverters.ListComparer<QuestionDefinition>());
+
+        builder.Property(e => e.EventIds)
+            .HasColumnType("jsonb")
+            .HasConversion(JsonbConverters.ListConverter<Guid>())
+            .Metadata.SetValueComparer(JsonbConverters.ListComparer<Guid>());
+
+        builder.Property(e => e.CustomEvents)
+            .HasColumnType("jsonb")
+            .HasConversion(JsonbConverters.ListConverter<CustomEventDefinition>())
+            .Metadata.SetValueComparer(JsonbConverters.ListComparer<CustomEventDefinition>());
+
+        builder.HasIndex(e => e.WeddingId);
+
+        // At most one flow per (wedding, passcode) when a passcode is set.
+        builder.HasIndex(e => new { e.WeddingId, e.Passcode })
+            .IsUnique()
+            .HasFilter("\"Passcode\" IS NOT NULL");
+
+        builder.HasOne(e => e.Wedding)
+            .WithMany()
+            .HasForeignKey(e => e.WeddingId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/WeddingManager.Infrastructure/Data/Configurations/JsonbConverters.cs
+++ b/WeddingManager.Infrastructure/Data/Configurations/JsonbConverters.cs
@@ -1,0 +1,26 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using WeddingManager.Domain.Models;
+
+namespace WeddingManager.Infrastructure.Data.Configurations;
+
+/// <summary>
+/// Builds EF value converters + comparers that store strongly-typed collections as jsonb,
+/// using the shared <see cref="RsvpJson.Options"/> so storage matches the API payloads.
+/// </summary>
+internal static class JsonbConverters
+{
+    public static ValueConverter<List<T>, string> ListConverter<T>() =>
+        new(
+            v => JsonSerializer.Serialize(v, RsvpJson.Options),
+            v => string.IsNullOrWhiteSpace(v)
+                ? new List<T>()
+                : JsonSerializer.Deserialize<List<T>>(v, RsvpJson.Options) ?? new List<T>());
+
+    public static ValueComparer<List<T>> ListComparer<T>() =>
+        new(
+            (a, b) => JsonSerializer.Serialize(a, RsvpJson.Options) == JsonSerializer.Serialize(b, RsvpJson.Options),
+            v => v == null ? 0 : JsonSerializer.Serialize(v, RsvpJson.Options).GetHashCode(),
+            v => JsonSerializer.Deserialize<List<T>>(JsonSerializer.Serialize(v, RsvpJson.Options), RsvpJson.Options) ?? new List<T>());
+}

--- a/WeddingManager.Infrastructure/Data/Configurations/RsvpResponseConfiguration.cs
+++ b/WeddingManager.Infrastructure/Data/Configurations/RsvpResponseConfiguration.cs
@@ -1,0 +1,46 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using WeddingManager.Domain.Entities;
+
+namespace WeddingManager.Infrastructure.Data.Configurations;
+
+public class RsvpResponseConfiguration : IEntityTypeConfiguration<RsvpResponse>
+{
+    public void Configure(EntityTypeBuilder<RsvpResponse> builder)
+    {
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Status)
+            .IsRequired()
+            .HasMaxLength(20)
+            .HasConversion<string>();
+
+        builder.Property(e => e.AttendingEventIds)
+            .HasColumnType("jsonb")
+            .HasConversion(JsonbConverters.ListConverter<Guid>())
+            .Metadata.SetValueComparer(JsonbConverters.ListComparer<Guid>());
+
+        builder.Property(e => e.CustomAnswers)
+            .IsRequired()
+            .HasColumnType("jsonb")
+            .HasDefaultValue("{}");
+
+        builder.HasIndex(e => new { e.WeddingId, e.InvitationFlowId });
+        builder.HasIndex(e => e.GuestId);
+
+        builder.HasOne(e => e.Wedding)
+            .WithMany()
+            .HasForeignKey(e => e.WeddingId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(e => e.InvitationFlow)
+            .WithMany(f => f.Responses)
+            .HasForeignKey(e => e.InvitationFlowId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(e => e.Guest)
+            .WithMany()
+            .HasForeignKey(e => e.GuestId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/WeddingManager.Infrastructure/Data/WeddingDbContext.cs
+++ b/WeddingManager.Infrastructure/Data/WeddingDbContext.cs
@@ -23,6 +23,8 @@ public class WeddingDbContext(DbContextOptions<WeddingDbContext> options)
     public DbSet<WeddingInvitation> WeddingInvitations => Set<WeddingInvitation>();
     public DbSet<Referral> Referrals => Set<Referral>();
     public DbSet<ReferralPayout> ReferralPayouts => Set<ReferralPayout>();
+    public DbSet<InvitationFlow> InvitationFlows => Set<InvitationFlow>();
+    public DbSet<RsvpResponse> RsvpResponses => Set<RsvpResponse>();
     
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/WeddingManager.Infrastructure/Extensions/DependencyInjection.cs
+++ b/WeddingManager.Infrastructure/Extensions/DependencyInjection.cs
@@ -65,6 +65,8 @@ public static class DependencyInjection
         services.AddScoped<IMediaRepository, MediaRepository>();
         services.AddScoped<IWeddingInvitationRepository, WeddingInvitationRepository>();
         services.AddScoped<IReferralRepository, ReferralRepository>();
+        services.AddScoped<IInvitationFlowRepository, InvitationFlowRepository>();
+        services.AddScoped<IRsvpResponseRepository, RsvpResponseRepository>();
         services.AddScoped<IMediaService, MediaService>();
 
         services.AddScoped<IObjectStorageService, ScalewayObjectStorageService>();

--- a/WeddingManager.Infrastructure/Migrations/20260528052123_AddRsvpFlows.Designer.cs
+++ b/WeddingManager.Infrastructure/Migrations/20260528052123_AddRsvpFlows.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WeddingManager.Infrastructure.Data;
@@ -11,9 +12,11 @@ using WeddingManager.Infrastructure.Data;
 namespace WeddingManager.Infrastructure.Migrations
 {
     [DbContext(typeof(WeddingDbContext))]
-    partial class WeddingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260528052123_AddRsvpFlows")]
+    partial class AddRsvpFlows
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/WeddingManager.Infrastructure/Migrations/20260528052123_AddRsvpFlows.cs
+++ b/WeddingManager.Infrastructure/Migrations/20260528052123_AddRsvpFlows.cs
@@ -1,0 +1,188 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WeddingManager.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRsvpFlows : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Guests_WeddingId_Email",
+                table: "Guests");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Dietary",
+                table: "Guests",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "PlusOneOfGuestId",
+                table: "Guests",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Surname",
+                table: "Guests",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true);
+
+            // Backfill so the composite dedupe index treats legacy rows deterministically.
+            migrationBuilder.Sql("UPDATE \"Guests\" SET \"Surname\" = '' WHERE \"Surname\" IS NULL;");
+
+            migrationBuilder.CreateTable(
+                name: "InvitationFlows",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    WeddingId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    Passcode = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    IncludePlusOne = table.Column<bool>(type: "boolean", nullable: false),
+                    CustomQuestions = table.Column<string>(type: "jsonb", nullable: false),
+                    EventIds = table.Column<string>(type: "jsonb", nullable: false),
+                    CustomEvents = table.Column<string>(type: "jsonb", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_InvitationFlows", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_InvitationFlows_Weddings_WeddingId",
+                        column: x => x.WeddingId,
+                        principalTable: "Weddings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "RsvpResponses",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    WeddingId = table.Column<Guid>(type: "uuid", nullable: false),
+                    InvitationFlowId = table.Column<Guid>(type: "uuid", nullable: false),
+                    GuestId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Status = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    AttendingEventIds = table.Column<string>(type: "jsonb", nullable: false),
+                    CustomAnswers = table.Column<string>(type: "jsonb", nullable: false, defaultValue: "{}"),
+                    SubmittedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RsvpResponses", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_RsvpResponses_Guests_GuestId",
+                        column: x => x.GuestId,
+                        principalTable: "Guests",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_RsvpResponses_InvitationFlows_InvitationFlowId",
+                        column: x => x.InvitationFlowId,
+                        principalTable: "InvitationFlows",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_RsvpResponses_Weddings_WeddingId",
+                        column: x => x.WeddingId,
+                        principalTable: "Weddings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Guests_PlusOneOfGuestId",
+                table: "Guests",
+                column: "PlusOneOfGuestId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InvitationFlows_WeddingId",
+                table: "InvitationFlows",
+                column: "WeddingId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InvitationFlows_WeddingId_Passcode",
+                table: "InvitationFlows",
+                columns: new[] { "WeddingId", "Passcode" },
+                unique: true,
+                filter: "\"Passcode\" IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RsvpResponses_GuestId",
+                table: "RsvpResponses",
+                column: "GuestId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RsvpResponses_InvitationFlowId",
+                table: "RsvpResponses",
+                column: "InvitationFlowId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RsvpResponses_WeddingId_InvitationFlowId",
+                table: "RsvpResponses",
+                columns: new[] { "WeddingId", "InvitationFlowId" });
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Guests_Guests_PlusOneOfGuestId",
+                table: "Guests",
+                column: "PlusOneOfGuestId",
+                principalTable: "Guests",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+
+            // Case-insensitive composite dedupe key. Functional (lower(...)) so it can't be
+            // expressed via the fluent API — created here as raw SQL. COALESCE keeps null
+            // surnames from defeating the constraint.
+            migrationBuilder.Sql(
+                "CREATE UNIQUE INDEX \"IX_Guests_Wedding_Email_Name_Surname_ci\" " +
+                "ON \"Guests\" (\"WeddingId\", lower(\"Email\"), lower(\"Name\"), lower(COALESCE(\"Surname\", '')));");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DROP INDEX IF EXISTS \"IX_Guests_Wedding_Email_Name_Surname_ci\";");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Guests_Guests_PlusOneOfGuestId",
+                table: "Guests");
+
+            migrationBuilder.DropTable(
+                name: "RsvpResponses");
+
+            migrationBuilder.DropTable(
+                name: "InvitationFlows");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Guests_PlusOneOfGuestId",
+                table: "Guests");
+
+            migrationBuilder.DropColumn(
+                name: "Dietary",
+                table: "Guests");
+
+            migrationBuilder.DropColumn(
+                name: "PlusOneOfGuestId",
+                table: "Guests");
+
+            migrationBuilder.DropColumn(
+                name: "Surname",
+                table: "Guests");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Guests_WeddingId_Email",
+                table: "Guests",
+                columns: new[] { "WeddingId", "Email" },
+                unique: true);
+        }
+    }
+}

--- a/WeddingManager.Infrastructure/Repositories/EventRepository.cs
+++ b/WeddingManager.Infrastructure/Repositories/EventRepository.cs
@@ -228,6 +228,15 @@ public class EventRepository(WeddingDbContext context, IUserContextService userC
             .ToListAsync();
     }
 
+    public async Task<IEnumerable<Event>> GetByWeddingIdUnscopedAsync(Guid weddingId)
+    {
+        return await context.Events
+            .AsNoTracking()
+            .Where(e => e.WeddingId == weddingId)
+            .OrderBy(e => e.StartDate)
+            .ToListAsync();
+    }
+
     private async Task<EventGuestChangeResult> RemoveGuestInternalAsync(Guid eventId, Guid guestId)
     {
         var eventToUpdate = await context.Events

--- a/WeddingManager.Infrastructure/Repositories/GuestRepository.cs
+++ b/WeddingManager.Infrastructure/Repositories/GuestRepository.cs
@@ -35,6 +35,19 @@ public class GuestRepository(WeddingDbContext context) : IGuestRepository
             .FirstOrDefaultAsync(g => g.WeddingId == weddingId && g.Email == email);
     }
 
+    public async Task<Guest?> FindByDedupeKeyAsync(Guid weddingId, string email, string name, string? surname)
+    {
+        var emailLower = email.ToLower();
+        var nameLower = name.ToLower();
+        var surnameLower = (surname ?? string.Empty).ToLower();
+        return await context.Guests
+            .FirstOrDefaultAsync(g =>
+                g.WeddingId == weddingId &&
+                g.Email.ToLower() == emailLower &&
+                g.Name.ToLower() == nameLower &&
+                (g.Surname ?? string.Empty).ToLower() == surnameLower);
+    }
+
     public async Task<int> CountByWeddingIdAsync(Guid weddingId)
     {
         return await context.Guests.CountAsync(g => g.WeddingId == weddingId);

--- a/WeddingManager.Infrastructure/Repositories/InvitationFlowRepository.cs
+++ b/WeddingManager.Infrastructure/Repositories/InvitationFlowRepository.cs
@@ -1,0 +1,52 @@
+using Microsoft.EntityFrameworkCore;
+using WeddingManager.Domain.Entities;
+using WeddingManager.Domain.Interfaces;
+using WeddingManager.Infrastructure.Data;
+
+namespace WeddingManager.Infrastructure.Repositories;
+
+public class InvitationFlowRepository(WeddingDbContext context) : IInvitationFlowRepository
+{
+    public async Task<IEnumerable<InvitationFlow>> GetByWeddingIdAsync(Guid weddingId)
+    {
+        return await context.InvitationFlows
+            .Where(f => f.WeddingId == weddingId)
+            .OrderBy(f => f.CreatedAt)
+            .ToListAsync();
+    }
+
+    public async Task<InvitationFlow?> GetByIdAsync(Guid flowId)
+    {
+        return await context.InvitationFlows
+            .Include(f => f.Wedding)
+            .FirstOrDefaultAsync(f => f.Id == flowId);
+    }
+
+    public async Task<InvitationFlow?> GetByPasscodeAsync(Guid weddingId, string passcode)
+    {
+        return await context.InvitationFlows
+            .FirstOrDefaultAsync(f => f.WeddingId == weddingId && f.Passcode == passcode);
+    }
+
+    public async Task AddAsync(InvitationFlow flow)
+    {
+        await context.InvitationFlows.AddAsync(flow);
+        await context.SaveChangesAsync();
+    }
+
+    public async Task UpdateAsync(InvitationFlow flow)
+    {
+        context.InvitationFlows.Update(flow);
+        await context.SaveChangesAsync();
+    }
+
+    public async Task DeleteAsync(Guid flowId)
+    {
+        var flow = await context.InvitationFlows.FindAsync(flowId);
+        if (flow != null)
+        {
+            context.InvitationFlows.Remove(flow);
+            await context.SaveChangesAsync();
+        }
+    }
+}

--- a/WeddingManager.Infrastructure/Repositories/RsvpResponseRepository.cs
+++ b/WeddingManager.Infrastructure/Repositories/RsvpResponseRepository.cs
@@ -1,0 +1,62 @@
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using WeddingManager.Domain.Entities;
+using WeddingManager.Domain.Interfaces;
+using WeddingManager.Infrastructure.Data;
+
+namespace WeddingManager.Infrastructure.Repositories;
+
+public class RsvpResponseRepository(WeddingDbContext context) : IRsvpResponseRepository
+{
+    public async Task<IReadOnlyDictionary<Guid, int>> GetCountsByWeddingAsync(Guid weddingId)
+    {
+        var counts = await context.RsvpResponses
+            .Where(r => r.WeddingId == weddingId)
+            .GroupBy(r => r.InvitationFlowId)
+            .Select(g => new { FlowId = g.Key, Count = g.Count() })
+            .ToListAsync();
+        return counts.ToDictionary(c => c.FlowId, c => c.Count);
+    }
+
+    public async Task<int> CountByFlowAsync(Guid flowId)
+    {
+        return await context.RsvpResponses.CountAsync(r => r.InvitationFlowId == flowId);
+    }
+
+    public async Task<IEnumerable<RsvpResponse>> GetByWeddingIdAsync(Guid weddingId, Guid? flowId)
+    {
+        var query = context.RsvpResponses
+            .Include(r => r.Guest)
+            .Include(r => r.InvitationFlow)
+            .Where(r => r.WeddingId == weddingId);
+
+        if (flowId.HasValue)
+        {
+            query = query.Where(r => r.InvitationFlowId == flowId.Value);
+        }
+
+        return await query
+            .OrderByDescending(r => r.SubmittedAt)
+            .ToListAsync();
+    }
+
+    public async Task<bool> SubmitAsync(IReadOnlyCollection<Guest> guests, IReadOnlyCollection<RsvpResponse> responses)
+    {
+        await context.Guests.AddRangeAsync(guests);
+        await context.RsvpResponses.AddRangeAsync(responses);
+        try
+        {
+            await context.SaveChangesAsync();
+            return true;
+        }
+        catch (DbUpdateException ex) when (ex.InnerException is PostgresException { SqlState: "23505" })
+        {
+            // Unique (dedupe) violation — clear the failed change tracker so the context is reusable.
+            foreach (var entry in context.ChangeTracker.Entries().ToList())
+            {
+                entry.State = EntityState.Detached;
+            }
+            return false;
+        }
+    }
+}

--- a/WeddingManager.Tests/InvitationFlowServiceTests.cs
+++ b/WeddingManager.Tests/InvitationFlowServiceTests.cs
@@ -1,0 +1,195 @@
+using Moq;
+using WeddingManager.Application.Mappings;
+using WeddingManager.Application.Services;
+using WeddingManager.Domain.DTO;
+using WeddingManager.Domain.Entities;
+using WeddingManager.Domain.Enums;
+using WeddingManager.Domain.Interfaces;
+using WeddingManager.Domain.Models;
+
+namespace WeddingManager.Tests;
+
+public class InvitationFlowServiceTests
+{
+    private readonly ApplicationMapper _mapper = new();
+
+    [Fact]
+    public async Task CreateAsync_CreatesOpenFlow_WhenNoOtherFlowsExist()
+    {
+        var flowRepo = new Mock<IInvitationFlowRepository>();
+        flowRepo.Setup(r => r.GetByWeddingIdAsync(It.IsAny<Guid>())).ReturnsAsync(new List<InvitationFlow>());
+        var service = CreateService(flowRepo);
+
+        var result = await service.CreateAsync(Guid.NewGuid(), new CreateInvitationFlowRequestDto { Name = "Everyone" });
+
+        Assert.True(result.IsSuccess);
+        Assert.Null(result.Value!.Passcode);
+        flowRepo.Verify(r => r.AddAsync(It.IsAny<InvitationFlow>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateAsync_RejectsOpenFlow_WhenOtherFlowsExist()
+    {
+        var weddingId = Guid.NewGuid();
+        var flowRepo = new Mock<IInvitationFlowRepository>();
+        flowRepo.Setup(r => r.GetByWeddingIdAsync(weddingId))
+            .ReturnsAsync(new List<InvitationFlow> { new() { Id = Guid.NewGuid(), WeddingId = weddingId, Passcode = "abc" } });
+        var service = CreateService(flowRepo);
+
+        var result = await service.CreateAsync(weddingId, new CreateInvitationFlowRequestDto { Name = "Open", Passcode = null });
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ErrorCodes.Conflict, result.Errors[0].Code);
+        flowRepo.Verify(r => r.AddAsync(It.IsAny<InvitationFlow>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateAsync_RejectsPasscodedFlow_WhenOpenFlowExists()
+    {
+        var weddingId = Guid.NewGuid();
+        var flowRepo = new Mock<IInvitationFlowRepository>();
+        flowRepo.Setup(r => r.GetByWeddingIdAsync(weddingId))
+            .ReturnsAsync(new List<InvitationFlow> { new() { Id = Guid.NewGuid(), WeddingId = weddingId, Passcode = null } });
+        var service = CreateService(flowRepo);
+
+        var result = await service.CreateAsync(weddingId, new CreateInvitationFlowRequestDto { Name = "Family", Passcode = "secret" });
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ErrorCodes.Conflict, result.Errors[0].Code);
+    }
+
+    [Fact]
+    public async Task CreateAsync_RejectsDuplicatePasscode()
+    {
+        var weddingId = Guid.NewGuid();
+        var flowRepo = new Mock<IInvitationFlowRepository>();
+        flowRepo.Setup(r => r.GetByWeddingIdAsync(weddingId))
+            .ReturnsAsync(new List<InvitationFlow> { new() { Id = Guid.NewGuid(), WeddingId = weddingId, Passcode = "secret" } });
+        var service = CreateService(flowRepo);
+
+        var result = await service.CreateAsync(weddingId, new CreateInvitationFlowRequestDto { Name = "Friends", Passcode = "secret" });
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ErrorCodes.Conflict, result.Errors[0].Code);
+    }
+
+    [Fact]
+    public async Task CreateAsync_AllowsSecondPasscodedFlow()
+    {
+        var weddingId = Guid.NewGuid();
+        var flowRepo = new Mock<IInvitationFlowRepository>();
+        flowRepo.Setup(r => r.GetByWeddingIdAsync(weddingId))
+            .ReturnsAsync(new List<InvitationFlow> { new() { Id = Guid.NewGuid(), WeddingId = weddingId, Passcode = "first" } });
+        var service = CreateService(flowRepo);
+
+        var result = await service.CreateAsync(weddingId, new CreateInvitationFlowRequestDto { Name = "Friends", Passcode = "second" });
+
+        Assert.True(result.IsSuccess);
+        flowRepo.Verify(r => r.AddAsync(It.IsAny<InvitationFlow>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateAsync_RejectsChoiceQuestionWithoutOptions()
+    {
+        var flowRepo = new Mock<IInvitationFlowRepository>();
+        flowRepo.Setup(r => r.GetByWeddingIdAsync(It.IsAny<Guid>())).ReturnsAsync(new List<InvitationFlow>());
+        var service = CreateService(flowRepo);
+
+        var request = new CreateInvitationFlowRequestDto
+        {
+            Name = "Flow",
+            CustomQuestions =
+            [
+                new QuestionDefinition { Type = RsvpQuestionType.SingleChoice, Label = "Pick", Options = [] }
+            ]
+        };
+
+        var result = await service.CreateAsync(Guid.NewGuid(), request);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ErrorCodes.Validation, result.Errors[0].Code);
+    }
+
+    [Fact]
+    public async Task CreateAsync_RejectsEventIdNotInWedding()
+    {
+        var weddingId = Guid.NewGuid();
+        var flowRepo = new Mock<IInvitationFlowRepository>();
+        flowRepo.Setup(r => r.GetByWeddingIdAsync(weddingId)).ReturnsAsync(new List<InvitationFlow>());
+        var eventRepo = new Mock<IEventRepository>();
+        eventRepo.Setup(r => r.GetByWeddingIdUnscopedAsync(weddingId)).ReturnsAsync(new List<Event>());
+        var service = CreateService(flowRepo, eventRepo: eventRepo);
+
+        var request = new CreateInvitationFlowRequestDto { Name = "Flow", EventIds = [Guid.NewGuid()] };
+
+        var result = await service.CreateAsync(weddingId, request);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ErrorCodes.Validation, result.Errors[0].Code);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_BlocksWhenResponsesExist_AndForceFalse()
+    {
+        var weddingId = Guid.NewGuid();
+        var flowId = Guid.NewGuid();
+        var flowRepo = new Mock<IInvitationFlowRepository>();
+        flowRepo.Setup(r => r.GetByIdAsync(flowId))
+            .ReturnsAsync(new InvitationFlow { Id = flowId, WeddingId = weddingId });
+        var responseRepo = new Mock<IRsvpResponseRepository>();
+        responseRepo.Setup(r => r.CountByFlowAsync(flowId)).ReturnsAsync(3);
+        var service = CreateService(flowRepo, responseRepo);
+
+        var result = await service.DeleteAsync(weddingId, flowId, force: false);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ErrorCodes.Conflict, result.Errors[0].Code);
+        flowRepo.Verify(r => r.DeleteAsync(It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_DeletesWhenForced()
+    {
+        var weddingId = Guid.NewGuid();
+        var flowId = Guid.NewGuid();
+        var flowRepo = new Mock<IInvitationFlowRepository>();
+        flowRepo.Setup(r => r.GetByIdAsync(flowId))
+            .ReturnsAsync(new InvitationFlow { Id = flowId, WeddingId = weddingId });
+        var responseRepo = new Mock<IRsvpResponseRepository>();
+        responseRepo.Setup(r => r.CountByFlowAsync(flowId)).ReturnsAsync(3);
+        var service = CreateService(flowRepo, responseRepo);
+
+        var result = await service.DeleteAsync(weddingId, flowId, force: true);
+
+        Assert.True(result.IsSuccess);
+        flowRepo.Verify(r => r.DeleteAsync(flowId), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ReturnsNotFound_WhenFlowBelongsToAnotherWedding()
+    {
+        var flowId = Guid.NewGuid();
+        var flowRepo = new Mock<IInvitationFlowRepository>();
+        flowRepo.Setup(r => r.GetByIdAsync(flowId))
+            .ReturnsAsync(new InvitationFlow { Id = flowId, WeddingId = Guid.NewGuid() });
+        var service = CreateService(flowRepo);
+
+        var result = await service.UpdateAsync(Guid.NewGuid(), flowId, new UpdateInvitationFlowRequestDto { Name = "X" });
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ErrorCodes.NotFound, result.Errors[0].Code);
+    }
+
+    private InvitationFlowService CreateService(
+        Mock<IInvitationFlowRepository> flowRepo,
+        Mock<IRsvpResponseRepository>? responseRepo = null,
+        Mock<IEventRepository>? eventRepo = null)
+    {
+        responseRepo ??= new Mock<IRsvpResponseRepository>();
+        responseRepo.Setup(r => r.GetCountsByWeddingAsync(It.IsAny<Guid>()))
+            .ReturnsAsync(new Dictionary<Guid, int>());
+        eventRepo ??= new Mock<IEventRepository>();
+        eventRepo.Setup(r => r.GetByWeddingIdUnscopedAsync(It.IsAny<Guid>())).ReturnsAsync(new List<Event>());
+        return new InvitationFlowService(flowRepo.Object, responseRepo.Object, eventRepo.Object, _mapper);
+    }
+}

--- a/WeddingManager.Tests/RsvpServiceTests.cs
+++ b/WeddingManager.Tests/RsvpServiceTests.cs
@@ -1,0 +1,219 @@
+using System.Text.Json;
+using Moq;
+using WeddingManager.Application.Services;
+using WeddingManager.Domain.DTO;
+using WeddingManager.Domain.Entities;
+using WeddingManager.Domain.Enums;
+using WeddingManager.Domain.Interfaces;
+using WeddingManager.Domain.Models;
+
+namespace WeddingManager.Tests;
+
+public class RsvpServiceTests
+{
+    private static readonly Guid WeddingId = Guid.NewGuid();
+
+    [Fact]
+    public async Task GetFlowStateAsync_ReturnsNoFlows_WhenNoneExist()
+    {
+        var ctx = new Context();
+        ctx.FlowRepo.Setup(r => r.GetByWeddingIdAsync(WeddingId)).ReturnsAsync(new List<InvitationFlow>());
+
+        var result = await ctx.Service.GetFlowStateAsync("slug");
+
+        Assert.True(result.IsSuccess);
+        Assert.False(result.Value!.HasFlows);
+    }
+
+    [Fact]
+    public async Task GetFlowStateAsync_ReturnsOpenFlowDirectly()
+    {
+        var ctx = new Context();
+        ctx.FlowRepo.Setup(r => r.GetByWeddingIdAsync(WeddingId))
+            .ReturnsAsync(new List<InvitationFlow> { Flow(passcode: null) });
+
+        var result = await ctx.Service.GetFlowStateAsync("slug");
+
+        Assert.True(result.IsSuccess);
+        Assert.True(result.Value!.HasFlows);
+        Assert.False(result.Value.RequiresPasscode);
+        Assert.NotNull(result.Value.Flow);
+    }
+
+    [Fact]
+    public async Task GetFlowStateAsync_RequiresPasscode_WhenAllFlowsGated()
+    {
+        var ctx = new Context();
+        ctx.FlowRepo.Setup(r => r.GetByWeddingIdAsync(WeddingId))
+            .ReturnsAsync(new List<InvitationFlow> { Flow(passcode: "abc") });
+
+        var result = await ctx.Service.GetFlowStateAsync("slug");
+
+        Assert.True(result.Value!.RequiresPasscode);
+        Assert.Null(result.Value.Flow);
+    }
+
+    [Fact]
+    public async Task UnlockAsync_ReturnsUnauthorized_OnWrongPasscode()
+    {
+        var ctx = new Context();
+        ctx.FlowRepo.Setup(r => r.GetByPasscodeAsync(WeddingId, "wrong")).ReturnsAsync((InvitationFlow?)null);
+
+        var result = await ctx.Service.UnlockAsync("slug", "wrong");
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ErrorCodes.Unauthorized, result.Errors[0].Code);
+    }
+
+    [Fact]
+    public async Task UnlockAsync_ReturnsFlow_OnCorrectPasscode()
+    {
+        var ctx = new Context();
+        ctx.FlowRepo.Setup(r => r.GetByPasscodeAsync(WeddingId, "secret")).ReturnsAsync(Flow(passcode: "secret"));
+
+        var result = await ctx.Service.UnlockAsync("slug", "secret");
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(WeddingId, result.Value!.WeddingId);
+    }
+
+    [Fact]
+    public async Task SubmitAsync_ReturnsConflict_WhenDuplicate()
+    {
+        var ctx = new Context();
+        var flow = Flow(passcode: "secret");
+        ctx.FlowRepo.Setup(r => r.GetByIdAsync(flow.Id)).ReturnsAsync(flow);
+        ctx.GuestRepo.Setup(r => r.FindByDedupeKeyAsync(WeddingId, "jane@x.com", "Jane", "Doe"))
+            .ReturnsAsync(new Guest { Id = Guid.NewGuid(), Name = "Jane" });
+
+        var result = await ctx.Service.SubmitAsync("slug", flow.Id, ValidSubmit());
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ErrorCodes.Conflict, result.Errors[0].Code);
+        ctx.ResponseRepo.Verify(r => r.SubmitAsync(It.IsAny<IReadOnlyCollection<Guest>>(),
+            It.IsAny<IReadOnlyCollection<RsvpResponse>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SubmitAsync_CreatesGuestAndResponse()
+    {
+        var ctx = new Context();
+        var flow = Flow(passcode: "secret");
+        ctx.FlowRepo.Setup(r => r.GetByIdAsync(flow.Id)).ReturnsAsync(flow);
+        IReadOnlyCollection<Guest>? capturedGuests = null;
+        IReadOnlyCollection<RsvpResponse>? capturedResponses = null;
+        ctx.ResponseRepo
+            .Setup(r => r.SubmitAsync(It.IsAny<IReadOnlyCollection<Guest>>(), It.IsAny<IReadOnlyCollection<RsvpResponse>>()))
+            .Callback<IReadOnlyCollection<Guest>, IReadOnlyCollection<RsvpResponse>>((g, r) =>
+            {
+                capturedGuests = g;
+                capturedResponses = r;
+            })
+            .ReturnsAsync(true);
+
+        var result = await ctx.Service.SubmitAsync("slug", flow.Id, ValidSubmit());
+
+        Assert.True(result.IsSuccess);
+        Assert.Single(capturedGuests!);
+        Assert.Single(capturedResponses!);
+        Assert.Equal("Jane", capturedGuests!.First().Name);
+        Assert.Equal(RsvpStatus.Accepted, capturedGuests!.First().RsvpStatus);
+    }
+
+    [Fact]
+    public async Task SubmitAsync_CreatesPlusOneGuestAndResponse()
+    {
+        var ctx = new Context();
+        var flow = Flow(passcode: "secret");
+        flow.IncludePlusOne = true;
+        ctx.FlowRepo.Setup(r => r.GetByIdAsync(flow.Id)).ReturnsAsync(flow);
+        IReadOnlyCollection<Guest>? capturedGuests = null;
+        ctx.ResponseRepo
+            .Setup(r => r.SubmitAsync(It.IsAny<IReadOnlyCollection<Guest>>(), It.IsAny<IReadOnlyCollection<RsvpResponse>>()))
+            .Callback<IReadOnlyCollection<Guest>, IReadOnlyCollection<RsvpResponse>>((g, _) => capturedGuests = g)
+            .ReturnsAsync(true);
+
+        var submit = ValidSubmit();
+        submit.PlusOneAttending = true;
+        submit.PlusOneName = "John";
+
+        var result = await ctx.Service.SubmitAsync("slug", flow.Id, submit);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value!.PlusOneGuestId);
+        Assert.Equal(2, capturedGuests!.Count);
+        var plusOne = capturedGuests!.First(g => g.PlusOneOfGuestId != null);
+        Assert.Equal("John", plusOne.Name);
+        Assert.Equal("jane@x.com", plusOne.Email);
+    }
+
+    [Fact]
+    public async Task SubmitAsync_RejectsRequiredQuestionMissing()
+    {
+        var ctx = new Context();
+        var flow = Flow(passcode: "secret");
+        flow.CustomQuestions =
+        [
+            new QuestionDefinition { Id = Guid.NewGuid(), Type = RsvpQuestionType.FreeText, Label = "Song", Required = true }
+        ];
+        ctx.FlowRepo.Setup(r => r.GetByIdAsync(flow.Id)).ReturnsAsync(flow);
+
+        var result = await ctx.Service.SubmitAsync("slug", flow.Id, ValidSubmit());
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ErrorCodes.Validation, result.Errors[0].Code);
+    }
+
+    [Fact]
+    public async Task SubmitAsync_RejectsEventNotInFlow()
+    {
+        var ctx = new Context();
+        var flow = Flow(passcode: "secret");
+        ctx.FlowRepo.Setup(r => r.GetByIdAsync(flow.Id)).ReturnsAsync(flow);
+
+        var submit = ValidSubmit();
+        submit.AttendingEventIds = [Guid.NewGuid()];
+
+        var result = await ctx.Service.SubmitAsync("slug", flow.Id, submit);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ErrorCodes.Validation, result.Errors[0].Code);
+    }
+
+    private static InvitationFlow Flow(string? passcode) => new()
+    {
+        Id = Guid.NewGuid(),
+        WeddingId = WeddingId,
+        Name = "Flow",
+        Passcode = passcode
+    };
+
+    private static RsvpFlowSubmitRequestDto ValidSubmit() => new()
+    {
+        Name = "Jane",
+        Surname = "Doe",
+        Email = "jane@x.com",
+        Status = RsvpResponseStatus.Attending,
+        AttendingEventIds = new List<Guid>(),
+        CustomAnswers = new Dictionary<string, JsonElement>()
+    };
+
+    private sealed class Context
+    {
+        public Mock<IWeddingRepository> WeddingRepo { get; } = new();
+        public Mock<IInvitationFlowRepository> FlowRepo { get; } = new();
+        public Mock<IRsvpResponseRepository> ResponseRepo { get; } = new();
+        public Mock<IGuestRepository> GuestRepo { get; } = new();
+        public Mock<IEventRepository> EventRepo { get; } = new();
+        public RsvpService Service { get; }
+
+        public Context()
+        {
+            WeddingRepo.Setup(r => r.GetByIdOrSlugAsync(It.IsAny<string>()))
+                .ReturnsAsync(new Wedding { Id = WeddingId, Title = "Test", Slug = "slug" });
+            EventRepo.Setup(r => r.GetByWeddingIdUnscopedAsync(It.IsAny<Guid>())).ReturnsAsync(new List<Event>());
+            Service = new RsvpService(WeddingRepo.Object, FlowRepo.Object, ResponseRepo.Object,
+                GuestRepo.Object, EventRepo.Object);
+        }
+    }
+}

--- a/WeddingManager.Web/Endpoints/InvitationFlows/CreateInvitationFlowEndpoint.cs
+++ b/WeddingManager.Web/Endpoints/InvitationFlows/CreateInvitationFlowEndpoint.cs
@@ -1,0 +1,38 @@
+using WeddingManager.Domain.DTO;
+using WeddingManager.Domain.Enums;
+using WeddingManager.Domain.Interfaces;
+using WeddingManager.Web.Authorization;
+using WeddingManager.Web.Extensions;
+using WeddingManager.Web.Models;
+
+namespace WeddingManager.Web.Endpoints.InvitationFlows;
+
+public class CreateInvitationFlowEndpoint : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPost("/weddings/{weddingId}/invitation-flows",
+                async (Guid weddingId, CreateInvitationFlowRequestDto requestDto, IInvitationFlowService flowService) =>
+                {
+                    var result = await flowService.CreateAsync(weddingId, requestDto);
+                    if (!result.IsSuccess)
+                    {
+                        return result.ToErrorResult();
+                    }
+
+                    var flow = result.Value!;
+                    return Results.Created($"/api/weddings/{weddingId}/invitation-flows/{flow.Id}", flow);
+                })
+            .WithTags("InvitationFlows")
+            .WithName("CreateInvitationFlow")
+            .RequireAuthorization()
+            .AddEndpointFilter<RequireWeddingAccessFilter>()
+            .RequireModuleAccess(WeddingModule.Guests)
+            .Produces<InvitationFlowDto>(201)
+            .Produces<ErrorResponse>(400)
+            .Produces<ErrorResponse>(401)
+            .Produces<ErrorResponse>(403)
+            .Produces<ErrorResponse>(404)
+            .Produces<ErrorResponse>(409);
+    }
+}

--- a/WeddingManager.Web/Endpoints/InvitationFlows/DeleteInvitationFlowEndpoint.cs
+++ b/WeddingManager.Web/Endpoints/InvitationFlows/DeleteInvitationFlowEndpoint.cs
@@ -1,0 +1,30 @@
+using WeddingManager.Domain.Enums;
+using WeddingManager.Domain.Interfaces;
+using WeddingManager.Web.Authorization;
+using WeddingManager.Web.Extensions;
+using WeddingManager.Web.Models;
+
+namespace WeddingManager.Web.Endpoints.InvitationFlows;
+
+public class DeleteInvitationFlowEndpoint : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapDelete("/weddings/{weddingId}/invitation-flows/{flowId:guid}",
+                async (Guid weddingId, Guid flowId, bool? force, IInvitationFlowService flowService) =>
+                {
+                    var result = await flowService.DeleteAsync(weddingId, flowId, force ?? false);
+                    return result.IsSuccess ? Results.NoContent() : result.ToErrorResult();
+                })
+            .WithTags("InvitationFlows")
+            .WithName("DeleteInvitationFlow")
+            .RequireAuthorization()
+            .AddEndpointFilter<RequireWeddingAccessFilter>()
+            .RequireModuleAccess(WeddingModule.Guests)
+            .Produces(204)
+            .Produces<ErrorResponse>(401)
+            .Produces<ErrorResponse>(403)
+            .Produces<ErrorResponse>(404)
+            .Produces<ErrorResponse>(409);
+    }
+}

--- a/WeddingManager.Web/Endpoints/InvitationFlows/GetInvitationFlowsEndpoint.cs
+++ b/WeddingManager.Web/Endpoints/InvitationFlows/GetInvitationFlowsEndpoint.cs
@@ -1,0 +1,30 @@
+using WeddingManager.Domain.DTO;
+using WeddingManager.Domain.Enums;
+using WeddingManager.Domain.Interfaces;
+using WeddingManager.Web.Authorization;
+using WeddingManager.Web.Extensions;
+using WeddingManager.Web.Models;
+
+namespace WeddingManager.Web.Endpoints.InvitationFlows;
+
+public class GetInvitationFlowsEndpoint : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/weddings/{weddingId}/invitation-flows",
+                async (Guid weddingId, IInvitationFlowService flowService) =>
+                {
+                    var result = await flowService.GetByWeddingIdAsync(weddingId);
+                    return result.IsSuccess ? Results.Ok(result.Value) : result.ToErrorResult();
+                })
+            .WithTags("InvitationFlows")
+            .WithName("GetInvitationFlows")
+            .RequireAuthorization()
+            .AddEndpointFilter<RequireWeddingAccessFilter>()
+            .RequireModuleAccess(WeddingModule.Guests)
+            .Produces<IEnumerable<InvitationFlowDto>>(200)
+            .Produces<ErrorResponse>(401)
+            .Produces<ErrorResponse>(403)
+            .Produces<ErrorResponse>(404);
+    }
+}

--- a/WeddingManager.Web/Endpoints/InvitationFlows/GetRsvpResponsesEndpoint.cs
+++ b/WeddingManager.Web/Endpoints/InvitationFlows/GetRsvpResponsesEndpoint.cs
@@ -1,0 +1,30 @@
+using WeddingManager.Domain.DTO;
+using WeddingManager.Domain.Enums;
+using WeddingManager.Domain.Interfaces;
+using WeddingManager.Web.Authorization;
+using WeddingManager.Web.Extensions;
+using WeddingManager.Web.Models;
+
+namespace WeddingManager.Web.Endpoints.InvitationFlows;
+
+public class GetRsvpResponsesEndpoint : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/weddings/{weddingId}/rsvp-responses",
+                async (Guid weddingId, Guid? flowId, IRsvpService rsvpService) =>
+                {
+                    var result = await rsvpService.GetResponsesAsync(weddingId, flowId);
+                    return result.IsSuccess ? Results.Ok(result.Value) : result.ToErrorResult();
+                })
+            .WithTags("InvitationFlows")
+            .WithName("GetRsvpResponses")
+            .RequireAuthorization()
+            .AddEndpointFilter<RequireWeddingAccessFilter>()
+            .RequireModuleAccess(WeddingModule.Guests)
+            .Produces<IEnumerable<RsvpResponseDto>>(200)
+            .Produces<ErrorResponse>(401)
+            .Produces<ErrorResponse>(403)
+            .Produces<ErrorResponse>(404);
+    }
+}

--- a/WeddingManager.Web/Endpoints/InvitationFlows/UpdateInvitationFlowEndpoint.cs
+++ b/WeddingManager.Web/Endpoints/InvitationFlows/UpdateInvitationFlowEndpoint.cs
@@ -1,0 +1,33 @@
+using WeddingManager.Domain.DTO;
+using WeddingManager.Domain.Enums;
+using WeddingManager.Domain.Interfaces;
+using WeddingManager.Web.Authorization;
+using WeddingManager.Web.Extensions;
+using WeddingManager.Web.Models;
+
+namespace WeddingManager.Web.Endpoints.InvitationFlows;
+
+public class UpdateInvitationFlowEndpoint : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPut("/weddings/{weddingId}/invitation-flows/{flowId:guid}",
+                async (Guid weddingId, Guid flowId, UpdateInvitationFlowRequestDto requestDto,
+                    IInvitationFlowService flowService) =>
+                {
+                    var result = await flowService.UpdateAsync(weddingId, flowId, requestDto);
+                    return result.IsSuccess ? Results.Ok(result.Value) : result.ToErrorResult();
+                })
+            .WithTags("InvitationFlows")
+            .WithName("UpdateInvitationFlow")
+            .RequireAuthorization()
+            .AddEndpointFilter<RequireWeddingAccessFilter>()
+            .RequireModuleAccess(WeddingModule.Guests)
+            .Produces<InvitationFlowDto>(200)
+            .Produces<ErrorResponse>(400)
+            .Produces<ErrorResponse>(401)
+            .Produces<ErrorResponse>(403)
+            .Produces<ErrorResponse>(404)
+            .Produces<ErrorResponse>(409);
+    }
+}

--- a/WeddingManager.Web/Endpoints/Rsvp/GetRsvpFlowStateEndpoint.cs
+++ b/WeddingManager.Web/Endpoints/Rsvp/GetRsvpFlowStateEndpoint.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.DataProtection;
+using WeddingManager.Domain.DTO;
+using WeddingManager.Domain.Interfaces;
+using WeddingManager.Web.Extensions;
+using WeddingManager.Web.Models;
+
+namespace WeddingManager.Web.Endpoints.Rsvp;
+
+public class GetRsvpFlowStateEndpoint : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/public/weddings/{slug}/rsvp",
+                async (string slug, HttpContext http, IRsvpService rsvpService, IDataProtectionProvider dp) =>
+                {
+                    var result = await rsvpService.GetFlowStateAsync(slug);
+                    if (!result.IsSuccess)
+                    {
+                        return result.ToErrorResult();
+                    }
+
+                    // Open (no-passcode) flow: issue the ticket immediately so submit is uniform.
+                    var state = result.Value!;
+                    if (state is { RequiresPasscode: false, Flow: not null })
+                    {
+                        RsvpFlowCookie.Issue(http, dp, state.Flow.WeddingId, state.Flow.FlowId);
+                    }
+
+                    return Results.Ok(state);
+                })
+            .WithTags("Rsvp")
+            .WithName("GetRsvpFlowState")
+            .AllowAnonymous()
+            .RequireRateLimiting("PublicApi")
+            .Produces<RsvpFlowStateDto>(200)
+            .Produces<ErrorResponse>(404)
+            .Produces<ErrorResponse>(429);
+    }
+}

--- a/WeddingManager.Web/Endpoints/Rsvp/RsvpFlowCookie.cs
+++ b/WeddingManager.Web/Endpoints/Rsvp/RsvpFlowCookie.cs
@@ -1,0 +1,55 @@
+using Microsoft.AspNetCore.DataProtection;
+
+namespace WeddingManager.Web.Endpoints.Rsvp;
+
+/// <summary>
+/// Signed, short-lived cookie proving a guest unlocked (or reached an open) RSVP flow.
+/// Payload binds wedding + flow + expiry; no server-side session is stored.
+/// </summary>
+public static class RsvpFlowCookie
+{
+    public const string Name = "rsvp_flow";
+    private const string Purpose = "rsvp-flow-unlock.v1";
+    private static readonly TimeSpan Lifetime = TimeSpan.FromHours(1);
+
+    public static void Issue(HttpContext http, IDataProtectionProvider dp, Guid weddingId, Guid flowId)
+    {
+        var expires = DateTimeOffset.UtcNow.Add(Lifetime);
+        var payload = $"{weddingId:N}|{flowId:N}|{expires.ToUnixTimeSeconds()}";
+        var token = dp.CreateProtector(Purpose).Protect(payload);
+
+        http.Response.Cookies.Append(Name, token, new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = !http.Request.Host.Host.Equals("localhost", StringComparison.OrdinalIgnoreCase),
+            SameSite = SameSiteMode.Lax,
+            Path = "/",
+            MaxAge = Lifetime
+        });
+    }
+
+    /// <summary>
+    /// Returns the unlocked flow id from a valid, unexpired cookie. The flow's membership of the
+    /// wedding is verified downstream by the submit service, so the wedding binding is not re-checked here.
+    /// </summary>
+    public static Guid? ResolveFlowId(HttpContext http, IDataProtectionProvider dp)
+    {
+        if (!http.Request.Cookies.TryGetValue(Name, out var token) || string.IsNullOrEmpty(token))
+            return null;
+
+        try
+        {
+            var payload = dp.CreateProtector(Purpose).Unprotect(token);
+            var parts = payload.Split('|');
+            if (parts.Length != 3) return null;
+            if (!Guid.TryParseExact(parts[1], "N", out var flowId)) return null;
+            if (!long.TryParse(parts[2], out var expSeconds)) return null;
+            if (DateTimeOffset.FromUnixTimeSeconds(expSeconds) < DateTimeOffset.UtcNow) return null;
+            return flowId;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/WeddingManager.Web/Endpoints/Rsvp/SubmitRsvpFlowEndpoint.cs
+++ b/WeddingManager.Web/Endpoints/Rsvp/SubmitRsvpFlowEndpoint.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.DataProtection;
+using WeddingManager.Domain.DTO;
+using WeddingManager.Domain.Interfaces;
+using WeddingManager.Web.Extensions;
+using WeddingManager.Web.Models;
+
+namespace WeddingManager.Web.Endpoints.Rsvp;
+
+public class SubmitRsvpFlowEndpoint : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPost("/public/weddings/{slug}/rsvp/submit",
+                async (string slug, RsvpFlowSubmitRequestDto requestDto, HttpContext http,
+                    IRsvpService rsvpService, IDataProtectionProvider dp) =>
+                {
+                    var flowId = RsvpFlowCookie.ResolveFlowId(http, dp);
+                    if (flowId == null)
+                    {
+                        return Results.Json(
+                            new ErrorResponse { Errors = [new("unauthorized", "Unlock the RSVP form before submitting.")] },
+                            statusCode: StatusCodes.Status401Unauthorized);
+                    }
+
+                    var result = await rsvpService.SubmitAsync(slug, flowId.Value, requestDto);
+                    return result.IsSuccess ? Results.Ok(result.Value) : result.ToErrorResult();
+                })
+            .WithTags("Rsvp")
+            .WithName("SubmitRsvpFlow")
+            .AllowAnonymous()
+            .RequireRateLimiting("PublicApi")
+            .Produces<RsvpSubmitResultDto>(200)
+            .Produces<ErrorResponse>(400)
+            .Produces<ErrorResponse>(401)
+            .Produces<ErrorResponse>(404)
+            .Produces<ErrorResponse>(409)
+            .Produces<ErrorResponse>(429);
+    }
+}

--- a/WeddingManager.Web/Endpoints/Rsvp/UnlockRsvpFlowEndpoint.cs
+++ b/WeddingManager.Web/Endpoints/Rsvp/UnlockRsvpFlowEndpoint.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.DataProtection;
+using WeddingManager.Domain.DTO;
+using WeddingManager.Domain.Interfaces;
+using WeddingManager.Web.Extensions;
+using WeddingManager.Web.Models;
+
+namespace WeddingManager.Web.Endpoints.Rsvp;
+
+public class UnlockRsvpFlowEndpoint : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPost("/public/weddings/{slug}/rsvp/unlock",
+                async (string slug, RsvpUnlockRequestDto requestDto, HttpContext http,
+                    IRsvpService rsvpService, IDataProtectionProvider dp) =>
+                {
+                    var result = await rsvpService.UnlockAsync(slug, requestDto.Passcode);
+                    if (!result.IsSuccess)
+                    {
+                        return result.ToErrorResult();
+                    }
+
+                    var flow = result.Value!;
+                    RsvpFlowCookie.Issue(http, dp, flow.WeddingId, flow.FlowId);
+                    return Results.Ok(flow);
+                })
+            .WithTags("Rsvp")
+            .WithName("UnlockRsvpFlow")
+            .AllowAnonymous()
+            .RequireRateLimiting("RsvpUnlock")
+            .Produces<RsvpFlowPublicDto>(200)
+            .Produces<ErrorResponse>(401)
+            .Produces<ErrorResponse>(404)
+            .Produces<ErrorResponse>(429);
+    }
+}

--- a/WeddingManager.Web/Extensions/RateLimitingExtensions.cs
+++ b/WeddingManager.Web/Extensions/RateLimitingExtensions.cs
@@ -55,6 +55,17 @@ public static class RateLimitingExtensions
                     QueueLimit = 0
                 });
             });
+            options.AddPolicy("RsvpUnlock", context =>
+            {
+                var partitionKey = context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+                return RateLimitPartition.GetFixedWindowLimiter(partitionKey, _ => new FixedWindowRateLimiterOptions
+                {
+                    PermitLimit = 5,
+                    Window = TimeSpan.FromMinutes(1),
+                    QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                    QueueLimit = 0
+                });
+            });
         });
 
         return services;

--- a/WeddingManager.Web/Program.cs
+++ b/WeddingManager.Web/Program.cs
@@ -26,6 +26,7 @@ builder.Services.AddOpenApi();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddAuthorization();
+builder.Services.AddDataProtection();
 builder.Services.AddPublicRateLimiting();
 
 var app = builder.Build();


### PR DESCRIPTION
## Summary
- New `InvitationFlow` + `RsvpResponse` entities with EF migration `20260528052123_AddRsvpFlows`. Adds `Surname`, `Dietary`, `PlusOneOfGuestId` to `Guest`; replaces the `(WeddingId, Email)` unique constraint with a case-insensitive composite `(WeddingId, lower(Email), lower(Name), lower(Surname))` so plus-ones can share the inviter's email.
- Couples create either one open (no-passcode) flow OR several passcode-protected flows — invariant enforced in `InvitationFlowService.ValidateExclusivity`. Each flow can include a plus-one block, custom questions (yes/no, free text, single/multi choice), and a mix of existing wedding events + flow-local custom events.
- Public path: `GET /public/weddings/{slug}/rsvp` → state + auto-issue cookie for an open flow; `POST .../unlock` → IP rate-limited (5/min) passcode check that sets a signed Data Protection cookie; `POST .../submit` → reads cookie, validates against the flow, persists guest(s) + response(s) in one transaction (plus-one inherits inviter's email, gets its own Guest row + response).
- Couple endpoints under `/weddings/{id}/invitation-flows*` and `/weddings/{id}/rsvp-responses` reuse `RequireWeddingAccessFilter` + `RequireModuleAccess(WeddingModule.Guests)` — owners and guest-access collaborators both qualify.
- `GuestDto` now exposes `Surname`, `Dietary`, `PlusOneOfGuestId` so the existing guest list can show full names and flag plus-ones.
- 235 tests green (including new `InvitationFlowServiceTests`, `RsvpServiceTests`).

Companion frontend PR: https://github.com/Sillves/amare-wedding-frontend/pulls

## Test plan
- [ ] `dotnet test` green
- [ ] Migration applies cleanly to a fresh dev DB
- [ ] Create flow, exclusivity rejects an open flow alongside passcoded ones
- [ ] Public unlock with wrong passcode → 401 (within rate limit); right → cookie issued
- [ ] Submit creates Guest + RsvpResponse; plus-one creates a second of each linked via `PlusOneOfGuestId`
- [ ] Re-submit with same name/email → 409 (dedupe)
- [ ] Declined submission with required questions still succeeds (no validation)
- [ ] `GET /weddings/{id}/rsvp-responses` returns rows with `attendingEventNames` resolved (real + custom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)