### PR TITLE
Prune dangling Docker images and stopped containers after deploy

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -207,6 +207,12 @@ jobs:
             docker-compose up -d
             sleep 5
 
+            # Reclaim disk: drop dangling images (orphaned by the new :latest pull)
+            # and stopped containers. Running containers, tagged images, and volumes
+            # are untouched.
+            docker image prune -f || true
+            docker container prune -f || true
+
       - name: Notify deployment
         if: success()
         run: echo "Deployment successful!"


### PR DESCRIPTION
## Summary
Every deploy does `docker-compose pull` against `:latest` tags, which overwrites the tag and leaves the previous image as a dangling layer on disk. Over dozens of deploys that adds several GB to the VPS.

Adds two lines after `docker-compose up -d` succeeds:

```
docker image prune -f   # removes dangling (untagged) images only
docker container prune -f   # removes stopped containers only
```

Safe by construction — neither flag touches running containers, tagged images, or volumes. Wrapped in `|| true` so a transient prune failure never breaks the deploy.

## Test plan
- [ ] Workflow YAML still parses (GitHub will block bad syntax)
- [ ] After next deploy, SSH to VPS and confirm `docker images --filter dangling=true` returns nothing immediately post-deploy
- [ ] Disk usage on `/var/lib/docker` trends flat across subsequent deploys instead of growing

🤖 Generated with [Claude Code](https://claude.com/claude-code)