### PR TITLE
feat(website): add MinimalArchitecture template (value 3)

### DIFF
--- a/WeddingManager.Application/Services/WeddingWebsiteService.cs
+++ b/WeddingManager.Application/Services/WeddingWebsiteService.cs
@@ -286,6 +286,12 @@ public class WeddingWebsiteService(
                 ["fontFamily"] = "script",
                 ["floralStyle"] = "watercolor"
             },
+            WebsiteTemplate.MinimalArchitecture => new Dictionary<string, string>
+            {
+                ["primaryColor"] = "#1A1A1A",
+                ["accentColor"] = "#8E9794",
+                ["fontFamily"] = "serif"
+            },
             _ => new Dictionary<string, string>
             {
                 ["primaryColor"] = "#8B7355",

--- a/WeddingManager.Domain/Enums/WebsiteTemplate.cs
+++ b/WeddingManager.Domain/Enums/WebsiteTemplate.cs
@@ -4,5 +4,6 @@ public enum WebsiteTemplate
 {
     ElegantClassic = 0,
     ModernMinimal = 1,
-    RomanticGarden = 2
+    RomanticGarden = 2,
+    MinimalArchitecture = 3
 }

--- a/WeddingManager.Web/Program.cs
+++ b/WeddingManager.Web/Program.cs
@@ -1,4 +1,6 @@
+using Microsoft.EntityFrameworkCore;
 using WeddingManager.Application.Extensions;
+using WeddingManager.Infrastructure.Data;
 using WeddingManager.Infrastructure.Extensions;
 using WeddingManager.Web.Endpoints;
 using WeddingManager.Web.Extensions;
@@ -30,6 +32,16 @@ builder.Services.AddDataProtection();
 builder.Services.AddPublicRateLimiting();
 
 var app = builder.Build();
+
+// Auto-apply EF Core migrations in Development so the containerised API is
+// self-sufficient (no host-side `dotnet ef` step needed). Production is
+// unaffected and keeps using the explicit migration scripts.
+if (app.Environment.IsDevelopment())
+{
+    using var scope = app.Services.CreateScope();
+    var db = scope.ServiceProvider.GetRequiredService<WeddingDbContext>();
+    db.Database.Migrate();
+}
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())


### PR DESCRIPTION
## Summary
Adds backend support for a **4th wedding-website template** — "Modern Minimalistisch" (`MinimalArchitecture`), a cold, architectural editorial style.

- `WebsiteTemplate.MinimalArchitecture = 3` (enum)
- Default settings for the template: `primaryColor #1A1A1A`, `accentColor #8E9794`, `fontFamily serif`
- **Dev-only**: apply EF Core migrations on startup when `IsDevelopment()`, so the containerised local API is self-sufficient. Production behaviour is unchanged (still uses the explicit migration scripts).

No DB migration needed — `Template` is stored as an int, so an extra enum value doesn't change the schema.

## Paired frontend PR
Requires Sillves/amare-wedding-frontend#8 (renders template value 3). Merge/deploy backend first so the OpenAPI enum includes `3`.

## Testing
- `dotnet test` → 235/235 passing
- Verified end-to-end via a local Docker stack: created + published a website with template 3 and rendered it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)