### PR TITLE
feat: website-toegangscode met gepersonaliseerde events

### DIFF
--- a/WeddingManager.Application/Services/RsvpService.cs
+++ b/WeddingManager.Application/Services/RsvpService.cs
@@ -14,7 +14,7 @@ public class RsvpService(
     IGuestRepository guestRepository,
     IEventRepository eventRepository) : IRsvpService
 {
-    public async Task<Result<RsvpFlowStateDto>> GetFlowStateAsync(string weddingSlugOrId)
+    public async Task<Result<RsvpFlowStateDto>> GetFlowStateAsync(string weddingSlugOrId, Guid? unlockedFlowId)
     {
         var wedding = await weddingRepository.GetByIdOrSlugAsync(weddingSlugOrId);
         if (wedding == null)
@@ -34,6 +34,23 @@ public class RsvpService(
                 RequiresPasscode = false,
                 Flow = dto
             });
+        }
+
+        // Already unlocked (e.g. via the website gate): the signed cookie names a flow of this
+        // wedding, so hand back the form directly instead of asking for the code again.
+        if (unlockedFlowId != null)
+        {
+            var unlockedFlow = flows.FirstOrDefault(f => f.Id == unlockedFlowId.Value);
+            if (unlockedFlow != null)
+            {
+                var dto = await BuildPublicFlowAsync(wedding.Id, unlockedFlow);
+                return Result<RsvpFlowStateDto>.Ok(new RsvpFlowStateDto
+                {
+                    HasFlows = true,
+                    RequiresPasscode = false,
+                    Flow = dto
+                });
+            }
         }
 
         return Result<RsvpFlowStateDto>.Ok(new RsvpFlowStateDto

--- a/WeddingManager.Application/Services/WeddingWebsiteService.cs
+++ b/WeddingManager.Application/Services/WeddingWebsiteService.cs
@@ -12,6 +12,7 @@ public class WeddingWebsiteService(
     IWeddingWebsiteRepository websiteRepository,
     IWeddingRepository weddingRepository,
     IEventRepository eventRepository,
+    IInvitationFlowRepository flowRepository,
     ApplicationMapper mapper) : IWeddingWebsiteService
 {
     public async Task<Result<WeddingWebsiteDto>> GetByWeddingIdAsync(Guid weddingId)
@@ -139,14 +140,45 @@ public class WeddingWebsiteService(
         return Result<WeddingWebsiteDto>.Ok(mapper.WebsiteToDto(updatedWebsite!));
     }
 
-    public async Task<Result<PublicWeddingWebsiteDto>> GetPublicBySlugAsync(string slug)
+    public async Task<Result<PublicWebsiteStateDto>> GetPublicBySlugAsync(string slug, Guid? unlockedFlowId)
     {
         var website = await websiteRepository.GetPublishedBySlugAsync(slug);
         if (website == null)
         {
-            return Result<PublicWeddingWebsiteDto>.Fail(new Error(ErrorCodes.NotFound, "Website not found or not published"));
+            return Result<PublicWebsiteStateDto>.Fail(new Error(ErrorCodes.NotFound, "Website not found or not published"));
         }
 
+        // Resolve which flow (if any) personalises this visit, and whether a passcode is still required.
+        var flows = (await flowRepository.GetByWeddingIdAsync(website.WeddingId)).ToList();
+        InvitationFlow? activeFlow = null;
+        if (flows.Count > 0)
+        {
+            var openFlow = flows.FirstOrDefault(f => f.Passcode == null);
+            if (openFlow != null)
+            {
+                // Open flow: no code needed, but events still follow the flow.
+                activeFlow = openFlow;
+            }
+            else
+            {
+                // Passcode-protected flows: require a valid unlocked flow belonging to this wedding.
+                activeFlow = unlockedFlowId == null
+                    ? null
+                    : flows.FirstOrDefault(f => f.Id == unlockedFlowId.Value);
+
+                if (activeFlow == null)
+                {
+                    return Result<PublicWebsiteStateDto>.Ok(new PublicWebsiteStateDto { RequiresPasscode = true });
+                }
+            }
+        }
+
+        var dto = await BuildPublicWebsiteDtoAsync(website, activeFlow);
+        return Result<PublicWebsiteStateDto>.Ok(new PublicWebsiteStateDto { RequiresPasscode = false, Website = dto });
+    }
+
+    private async Task<PublicWeddingWebsiteDto> BuildPublicWebsiteDtoAsync(WeddingWebsite website, InvitationFlow? activeFlow)
+    {
         var dto = new PublicWeddingWebsiteDto
         {
             WeddingSlug = website.Wedding.Slug,
@@ -158,7 +190,7 @@ public class WeddingWebsiteService(
             Content = JsonDocument.Parse(website.Content)
         };
 
-        // Include events if the events section is enabled
+        // Include events if the events section is enabled, filtered to the active flow when present.
         var content = JsonDocument.Parse(website.Content);
         if (content.RootElement.TryGetProperty("events", out var eventsSection) &&
             eventsSection.TryGetProperty("enabled", out var enabled) &&
@@ -166,11 +198,15 @@ public class WeddingWebsiteService(
             eventsSection.TryGetProperty("showFromWeddingEvents", out var showEvents) &&
             showEvents.GetBoolean())
         {
-            var events = await eventRepository.GetByWeddingIdForPublicAsync(website.WeddingId);
+            IEnumerable<Event> events = await eventRepository.GetByWeddingIdForPublicAsync(website.WeddingId);
+            if (activeFlow != null)
+            {
+                events = events.Where(e => activeFlow.EventIds.Contains(e.Id));
+            }
             dto.Events = events.Select(e => mapper.EventToDto(e)).ToList();
         }
 
-        return Result<PublicWeddingWebsiteDto>.Ok(dto);
+        return dto;
     }
 
     public async Task<Result> DeleteAsync(Guid weddingId)

--- a/WeddingManager.Application/Services/WeddingWebsiteService.cs
+++ b/WeddingManager.Application/Services/WeddingWebsiteService.cs
@@ -203,7 +203,14 @@ public class WeddingWebsiteService(
             {
                 events = events.Where(e => activeFlow.EventIds.Contains(e.Id));
             }
-            dto.Events = events.Select(e => mapper.EventToDto(e)).ToList();
+            // Public, anonymous endpoint: never expose the guest list. EventToDto maps guests, so
+            // strip them here — the website only needs name/date/location/description of an event.
+            dto.Events = events.Select(e =>
+            {
+                var eventDto = mapper.EventToDto(e);
+                eventDto.GuestDtos = new List<GuestDto>();
+                return eventDto;
+            }).ToList();
         }
 
         return dto;

--- a/WeddingManager.Domain/DTO/PublicWebsiteStateDto.cs
+++ b/WeddingManager.Domain/DTO/PublicWebsiteStateDto.cs
@@ -1,0 +1,12 @@
+namespace WeddingManager.Domain.DTO;
+
+/// <summary>
+/// Public state for a wedding website. When the wedding has passcode-protected flows and the
+/// caller has not unlocked one, <see cref="RequiresPasscode"/> is true and <see cref="Website"/>
+/// is null so no content leaks to guests, crawlers, or link previews.
+/// </summary>
+public class PublicWebsiteStateDto
+{
+    public bool RequiresPasscode { get; set; }
+    public PublicWeddingWebsiteDto? Website { get; set; }
+}

--- a/WeddingManager.Domain/Interfaces/IRsvpService.cs
+++ b/WeddingManager.Domain/Interfaces/IRsvpService.cs
@@ -5,7 +5,7 @@ namespace WeddingManager.Domain.Interfaces;
 
 public interface IRsvpService
 {
-    Task<Result<RsvpFlowStateDto>> GetFlowStateAsync(string weddingSlugOrId);
+    Task<Result<RsvpFlowStateDto>> GetFlowStateAsync(string weddingSlugOrId, Guid? unlockedFlowId);
     Task<Result<RsvpFlowPublicDto>> UnlockAsync(string weddingSlugOrId, string passcode);
     Task<Result<RsvpSubmitResultDto>> SubmitAsync(string weddingSlugOrId, Guid flowId, RsvpFlowSubmitRequestDto requestDto);
 

--- a/WeddingManager.Domain/Interfaces/IWeddingWebsiteService.cs
+++ b/WeddingManager.Domain/Interfaces/IWeddingWebsiteService.cs
@@ -10,6 +10,6 @@ public interface IWeddingWebsiteService
     Task<Result<WeddingWebsiteDto>> UpdateAsync(Guid weddingId, UpdateWeddingWebsiteRequestDto request);
     Task<Result<WeddingWebsiteDto>> PublishAsync(Guid weddingId);
     Task<Result<WeddingWebsiteDto>> UnpublishAsync(Guid weddingId);
-    Task<Result<PublicWeddingWebsiteDto>> GetPublicBySlugAsync(string slug);
+    Task<Result<PublicWebsiteStateDto>> GetPublicBySlugAsync(string slug, Guid? unlockedFlowId);
     Task<Result> DeleteAsync(Guid weddingId);
 }

--- a/WeddingManager.Tests/RsvpServiceTests.cs
+++ b/WeddingManager.Tests/RsvpServiceTests.cs
@@ -19,7 +19,7 @@ public class RsvpServiceTests
         var ctx = new Context();
         ctx.FlowRepo.Setup(r => r.GetByWeddingIdAsync(WeddingId)).ReturnsAsync(new List<InvitationFlow>());
 
-        var result = await ctx.Service.GetFlowStateAsync("slug");
+        var result = await ctx.Service.GetFlowStateAsync("slug", null);
 
         Assert.True(result.IsSuccess);
         Assert.False(result.Value!.HasFlows);
@@ -32,7 +32,7 @@ public class RsvpServiceTests
         ctx.FlowRepo.Setup(r => r.GetByWeddingIdAsync(WeddingId))
             .ReturnsAsync(new List<InvitationFlow> { Flow(passcode: null) });
 
-        var result = await ctx.Service.GetFlowStateAsync("slug");
+        var result = await ctx.Service.GetFlowStateAsync("slug", null);
 
         Assert.True(result.IsSuccess);
         Assert.True(result.Value!.HasFlows);
@@ -47,7 +47,36 @@ public class RsvpServiceTests
         ctx.FlowRepo.Setup(r => r.GetByWeddingIdAsync(WeddingId))
             .ReturnsAsync(new List<InvitationFlow> { Flow(passcode: "abc") });
 
-        var result = await ctx.Service.GetFlowStateAsync("slug");
+        var result = await ctx.Service.GetFlowStateAsync("slug", null);
+
+        Assert.True(result.Value!.RequiresPasscode);
+        Assert.Null(result.Value.Flow);
+    }
+
+    [Fact]
+    public async Task GetFlowStateAsync_ReturnsFlowDirectly_WhenUnlockedFlowMatches()
+    {
+        var ctx = new Context();
+        var flow = Flow(passcode: "abc");
+        ctx.FlowRepo.Setup(r => r.GetByWeddingIdAsync(WeddingId))
+            .ReturnsAsync(new List<InvitationFlow> { flow });
+
+        var result = await ctx.Service.GetFlowStateAsync("slug", flow.Id);
+
+        Assert.True(result.IsSuccess);
+        Assert.False(result.Value!.RequiresPasscode);
+        Assert.NotNull(result.Value.Flow);
+        Assert.Equal(flow.Id, result.Value.Flow!.FlowId);
+    }
+
+    [Fact]
+    public async Task GetFlowStateAsync_RequiresPasscode_WhenUnlockedFlowUnknown()
+    {
+        var ctx = new Context();
+        ctx.FlowRepo.Setup(r => r.GetByWeddingIdAsync(WeddingId))
+            .ReturnsAsync(new List<InvitationFlow> { Flow(passcode: "abc") });
+
+        var result = await ctx.Service.GetFlowStateAsync("slug", Guid.NewGuid());
 
         Assert.True(result.Value!.RequiresPasscode);
         Assert.Null(result.Value.Flow);

--- a/WeddingManager.Tests/WeddingWebsiteServiceTests.cs
+++ b/WeddingManager.Tests/WeddingWebsiteServiceTests.cs
@@ -451,6 +451,36 @@ public class WeddingWebsiteServiceTests
     }
 
     [Fact]
+    public async Task GetPublicBySlugAsync_NeverExposesGuestList()
+    {
+        var weddingId = Guid.NewGuid();
+        var content = """{"events":{"enabled":true,"showFromWeddingEvents":true}}""";
+        var website = CreateWebsiteEntity(weddingId, isPublished: true, content: content);
+        var events = new List<Event>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(), WeddingId = weddingId, Name = "Ceremony", Location = "Church", StartDate = DateTime.UtcNow,
+                Guests = new List<Guest>
+                {
+                    new() { Id = Guid.NewGuid(), Name = "Jane", Surname = "Doe", Email = "jane@x.com" }
+                }
+            }
+        };
+        var websiteRepoMock = new Mock<IWeddingWebsiteRepository>();
+        websiteRepoMock.Setup(r => r.GetPublishedBySlugAsync("test-wedding")).ReturnsAsync(website);
+        var eventRepoMock = new Mock<IEventRepository>();
+        eventRepoMock.Setup(r => r.GetByWeddingIdForPublicAsync(weddingId)).ReturnsAsync(events);
+        var service = CreateService(websiteRepoMock, eventRepoMock: eventRepoMock);
+
+        var result = await service.GetPublicBySlugAsync("test-wedding", null);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value!.Website!.Events);
+        Assert.All(result.Value.Website.Events!, e => Assert.Empty(e.GuestDtos));
+    }
+
+    [Fact]
     public async Task GetPublicBySlugAsync_ExcludesEventsWhenDisabled()
     {
         var content = """{"events":{"enabled":false,"showFromWeddingEvents":false}}""";

--- a/WeddingManager.Tests/WeddingWebsiteServiceTests.cs
+++ b/WeddingManager.Tests/WeddingWebsiteServiceTests.cs
@@ -17,15 +17,23 @@ public class WeddingWebsiteServiceTests
     private WeddingWebsiteService CreateService(
         Mock<IWeddingWebsiteRepository>? websiteRepoMock = null,
         Mock<IWeddingRepository>? weddingRepoMock = null,
-        Mock<IEventRepository>? eventRepoMock = null)
+        Mock<IEventRepository>? eventRepoMock = null,
+        Mock<IInvitationFlowRepository>? flowRepoMock = null)
     {
         websiteRepoMock ??= new Mock<IWeddingWebsiteRepository>();
         weddingRepoMock ??= new Mock<IWeddingRepository>();
         eventRepoMock ??= new Mock<IEventRepository>();
+        if (flowRepoMock == null)
+        {
+            flowRepoMock = new Mock<IInvitationFlowRepository>();
+            flowRepoMock.Setup(r => r.GetByWeddingIdAsync(It.IsAny<Guid>()))
+                .ReturnsAsync(new List<InvitationFlow>());
+        }
         return new WeddingWebsiteService(
             websiteRepoMock.Object,
             weddingRepoMock.Object,
             eventRepoMock.Object,
+            flowRepoMock.Object,
             _mapper);
     }
 
@@ -396,12 +404,13 @@ public class WeddingWebsiteServiceTests
         repoMock.Setup(r => r.GetPublishedBySlugAsync("test-wedding")).ReturnsAsync(website);
         var service = CreateService(websiteRepoMock: repoMock);
 
-        var result = await service.GetPublicBySlugAsync("test-wedding");
+        var result = await service.GetPublicBySlugAsync("test-wedding", null);
 
         Assert.True(result.IsSuccess);
-        Assert.Equal("test-wedding", result.Value!.WeddingSlug);
-        Assert.Equal("Test Wedding", result.Value.CoupleNames);
-        Assert.Equal(website.Wedding.Location, result.Value.WeddingLocation);
+        Assert.False(result.Value!.RequiresPasscode);
+        Assert.Equal("test-wedding", result.Value.Website!.WeddingSlug);
+        Assert.Equal("Test Wedding", result.Value.Website.CoupleNames);
+        Assert.Equal(website.Wedding.Location, result.Value.Website.WeddingLocation);
     }
 
     [Fact]
@@ -411,7 +420,7 @@ public class WeddingWebsiteServiceTests
         repoMock.Setup(r => r.GetPublishedBySlugAsync("ghost")).ReturnsAsync((WeddingWebsite?)null);
         var service = CreateService(websiteRepoMock: repoMock);
 
-        var result = await service.GetPublicBySlugAsync("ghost");
+        var result = await service.GetPublicBySlugAsync("ghost", null);
 
         Assert.False(result.IsSuccess);
         Assert.Equal(ErrorCodes.NotFound, result.Errors[0].Code);
@@ -434,11 +443,11 @@ public class WeddingWebsiteServiceTests
         eventRepoMock.Setup(r => r.GetByWeddingIdForPublicAsync(weddingId)).ReturnsAsync(events);
         var service = CreateService(websiteRepoMock, eventRepoMock: eventRepoMock);
 
-        var result = await service.GetPublicBySlugAsync("test-wedding");
+        var result = await service.GetPublicBySlugAsync("test-wedding", null);
 
         Assert.True(result.IsSuccess);
-        Assert.NotNull(result.Value!.Events);
-        Assert.Equal(2, result.Value.Events!.Count);
+        Assert.NotNull(result.Value!.Website!.Events);
+        Assert.Equal(2, result.Value.Website.Events!.Count);
     }
 
     [Fact]
@@ -451,11 +460,119 @@ public class WeddingWebsiteServiceTests
         var eventRepoMock = new Mock<IEventRepository>();
         var service = CreateService(websiteRepoMock, eventRepoMock: eventRepoMock);
 
-        var result = await service.GetPublicBySlugAsync("test-wedding");
+        var result = await service.GetPublicBySlugAsync("test-wedding", null);
 
         Assert.True(result.IsSuccess);
-        Assert.Null(result.Value!.Events);
+        Assert.Null(result.Value!.Website!.Events);
         eventRepoMock.Verify(r => r.GetByWeddingIdForPublicAsync(It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetPublicBySlugAsync_RequiresPasscode_WhenPasscodeFlowsAndNoUnlock()
+    {
+        var weddingId = Guid.NewGuid();
+        var website = CreateWebsiteEntity(weddingId, isPublished: true);
+        var websiteRepoMock = new Mock<IWeddingWebsiteRepository>();
+        websiteRepoMock.Setup(r => r.GetPublishedBySlugAsync("test-wedding")).ReturnsAsync(website);
+        var flowRepoMock = new Mock<IInvitationFlowRepository>();
+        flowRepoMock.Setup(r => r.GetByWeddingIdAsync(weddingId)).ReturnsAsync(new List<InvitationFlow>
+        {
+            new() { Id = Guid.NewGuid(), WeddingId = weddingId, Name = "Family", Passcode = "secret" }
+        });
+        var service = CreateService(websiteRepoMock, flowRepoMock: flowRepoMock);
+
+        var result = await service.GetPublicBySlugAsync("test-wedding", null);
+
+        Assert.True(result.IsSuccess);
+        Assert.True(result.Value!.RequiresPasscode);
+        Assert.Null(result.Value.Website);
+    }
+
+    [Fact]
+    public async Task GetPublicBySlugAsync_RequiresPasscode_WhenUnlockedFlowNotOfThisWedding()
+    {
+        var weddingId = Guid.NewGuid();
+        var website = CreateWebsiteEntity(weddingId, isPublished: true);
+        var websiteRepoMock = new Mock<IWeddingWebsiteRepository>();
+        websiteRepoMock.Setup(r => r.GetPublishedBySlugAsync("test-wedding")).ReturnsAsync(website);
+        var flowRepoMock = new Mock<IInvitationFlowRepository>();
+        flowRepoMock.Setup(r => r.GetByWeddingIdAsync(weddingId)).ReturnsAsync(new List<InvitationFlow>
+        {
+            new() { Id = Guid.NewGuid(), WeddingId = weddingId, Name = "Family", Passcode = "secret" }
+        });
+        var service = CreateService(websiteRepoMock, flowRepoMock: flowRepoMock);
+
+        var result = await service.GetPublicBySlugAsync("test-wedding", Guid.NewGuid());
+
+        Assert.True(result.IsSuccess);
+        Assert.True(result.Value!.RequiresPasscode);
+        Assert.Null(result.Value.Website);
+    }
+
+    [Fact]
+    public async Task GetPublicBySlugAsync_FiltersEventsToUnlockedFlow()
+    {
+        var weddingId = Guid.NewGuid();
+        var content = """{"events":{"enabled":true,"showFromWeddingEvents":true}}""";
+        var website = CreateWebsiteEntity(weddingId, isPublished: true, content: content);
+        var ceremonyId = Guid.NewGuid();
+        var receptionId = Guid.NewGuid();
+        var events = new List<Event>
+        {
+            new() { Id = ceremonyId, WeddingId = weddingId, Name = "Ceremony", Location = "Church", StartDate = DateTime.UtcNow, Guests = new List<Guest>() },
+            new() { Id = receptionId, WeddingId = weddingId, Name = "Reception", Location = "Ballroom", StartDate = DateTime.UtcNow, Guests = new List<Guest>() }
+        };
+        var flowId = Guid.NewGuid();
+        var websiteRepoMock = new Mock<IWeddingWebsiteRepository>();
+        websiteRepoMock.Setup(r => r.GetPublishedBySlugAsync("test-wedding")).ReturnsAsync(website);
+        var eventRepoMock = new Mock<IEventRepository>();
+        eventRepoMock.Setup(r => r.GetByWeddingIdForPublicAsync(weddingId)).ReturnsAsync(events);
+        var flowRepoMock = new Mock<IInvitationFlowRepository>();
+        flowRepoMock.Setup(r => r.GetByWeddingIdAsync(weddingId)).ReturnsAsync(new List<InvitationFlow>
+        {
+            new() { Id = flowId, WeddingId = weddingId, Name = "Ceremony only", Passcode = "secret", EventIds = new List<Guid> { ceremonyId } }
+        });
+        var service = CreateService(websiteRepoMock, eventRepoMock: eventRepoMock, flowRepoMock: flowRepoMock);
+
+        var result = await service.GetPublicBySlugAsync("test-wedding", flowId);
+
+        Assert.True(result.IsSuccess);
+        Assert.False(result.Value!.RequiresPasscode);
+        Assert.NotNull(result.Value.Website!.Events);
+        Assert.Single(result.Value.Website.Events!);
+        Assert.Equal("Ceremony", result.Value.Website.Events![0].Name);
+    }
+
+    [Fact]
+    public async Task GetPublicBySlugAsync_OpenFlow_FiltersEventsWithoutPasscode()
+    {
+        var weddingId = Guid.NewGuid();
+        var content = """{"events":{"enabled":true,"showFromWeddingEvents":true}}""";
+        var website = CreateWebsiteEntity(weddingId, isPublished: true, content: content);
+        var ceremonyId = Guid.NewGuid();
+        var receptionId = Guid.NewGuid();
+        var events = new List<Event>
+        {
+            new() { Id = ceremonyId, WeddingId = weddingId, Name = "Ceremony", Location = "Church", StartDate = DateTime.UtcNow, Guests = new List<Guest>() },
+            new() { Id = receptionId, WeddingId = weddingId, Name = "Reception", Location = "Ballroom", StartDate = DateTime.UtcNow, Guests = new List<Guest>() }
+        };
+        var websiteRepoMock = new Mock<IWeddingWebsiteRepository>();
+        websiteRepoMock.Setup(r => r.GetPublishedBySlugAsync("test-wedding")).ReturnsAsync(website);
+        var eventRepoMock = new Mock<IEventRepository>();
+        eventRepoMock.Setup(r => r.GetByWeddingIdForPublicAsync(weddingId)).ReturnsAsync(events);
+        var flowRepoMock = new Mock<IInvitationFlowRepository>();
+        flowRepoMock.Setup(r => r.GetByWeddingIdAsync(weddingId)).ReturnsAsync(new List<InvitationFlow>
+        {
+            new() { Id = Guid.NewGuid(), WeddingId = weddingId, Name = "Everyone", Passcode = null, EventIds = new List<Guid> { receptionId } }
+        });
+        var service = CreateService(websiteRepoMock, eventRepoMock: eventRepoMock, flowRepoMock: flowRepoMock);
+
+        var result = await service.GetPublicBySlugAsync("test-wedding", null);
+
+        Assert.True(result.IsSuccess);
+        Assert.False(result.Value!.RequiresPasscode);
+        Assert.Single(result.Value.Website!.Events!);
+        Assert.Equal("Reception", result.Value.Website.Events![0].Name);
     }
 
     // --- DeleteAsync ---

--- a/WeddingManager.Web/Endpoints/Rsvp/GetRsvpFlowStateEndpoint.cs
+++ b/WeddingManager.Web/Endpoints/Rsvp/GetRsvpFlowStateEndpoint.cs
@@ -13,7 +13,8 @@ public class GetRsvpFlowStateEndpoint : IEndpoint
         app.MapGet("/public/weddings/{slug}/rsvp",
                 async (string slug, HttpContext http, IRsvpService rsvpService, IDataProtectionProvider dp) =>
                 {
-                    var result = await rsvpService.GetFlowStateAsync(slug);
+                    var unlockedFlowId = RsvpFlowCookie.ResolveFlowId(http, dp);
+                    var result = await rsvpService.GetFlowStateAsync(slug, unlockedFlowId);
                     if (!result.IsSuccess)
                     {
                         return result.ToErrorResult();

--- a/WeddingManager.Web/Endpoints/Website/GetPublicWebsiteEndpoint.cs
+++ b/WeddingManager.Web/Endpoints/Website/GetPublicWebsiteEndpoint.cs
@@ -1,5 +1,7 @@
+using Microsoft.AspNetCore.DataProtection;
 using WeddingManager.Domain.DTO;
 using WeddingManager.Domain.Interfaces;
+using WeddingManager.Web.Endpoints.Rsvp;
 using WeddingManager.Web.Extensions;
 using WeddingManager.Web.Models;
 
@@ -10,16 +12,17 @@ public class GetPublicWebsiteEndpoint : IEndpoint
     public void MapEndpoint(IEndpointRouteBuilder app)
     {
         app.MapGet("/w/{slug}",
-                async (string slug, IWeddingWebsiteService websiteService) =>
+                async (string slug, HttpContext http, IWeddingWebsiteService websiteService, IDataProtectionProvider dp) =>
                 {
-                    var result = await websiteService.GetPublicBySlugAsync(slug);
+                    var unlockedFlowId = RsvpFlowCookie.ResolveFlowId(http, dp);
+                    var result = await websiteService.GetPublicBySlugAsync(slug, unlockedFlowId);
                     return result.IsSuccess ? Results.Ok(result.Value) : result.ToErrorResult();
                 })
             .WithTags("Public Website")
             .WithName("GetPublicWebsite")
             .AllowAnonymous()
             .RequireRateLimiting("PublicApi")
-            .Produces<PublicWeddingWebsiteDto>(200)
+            .Produces<PublicWebsiteStateDto>(200)
             .Produces<ErrorResponse>(404);
     }
 }

--- a/docs/superpowers/specs/2026-07-01-website-access-code-design.md
+++ b/docs/superpowers/specs/2026-07-01-website-access-code-design.md
@@ -1,0 +1,107 @@
+# Website-toegangscode & gepersonaliseerde content
+
+**Datum:** 2026-07-01
+**Status:** Goedgekeurd ontwerp
+**Repos:** `WeddingManagerApi` (backend), `amare-wedding-frontend` (frontend)
+
+## Probleem
+
+Koppels willen dat een gast eerst een code invult vóór de gepubliceerde website
+zichtbaar wordt. Op basis van die code wordt de content gepersonaliseerd (o.a. op
+welke events de gast is uitgenodigd). Omdat de code dan al is ingegeven, mag hij niet
+opnieuw gevraagd worden op de RSVP.
+
+## Uitgangspunt: bestaande bouwstenen
+
+De feature hergebruikt wat er al is; er komt géén nieuw code/beveiligingsconcept bij.
+
+- **`InvitationFlow.Passcode`** — de code. `ValidateExclusivity`
+  (`InvitationFlowService.cs:113`) dwingt al af: **ofwel** N flows die allemaal een
+  passcode hebben, **ofwel** exact één open flow zonder passcode. Een mix is onmogelijk.
+- **`RsvpFlowCookie`** (`RsvpFlowCookie.cs`) — gesigneerde, versleutelde, HttpOnly cookie
+  (`weddingId | flowId | expiry`, 1 uur) via `IDataProtectionProvider`. Bewijst dat deze
+  browser een geldige code heeft ingevoerd en bindt de gekozen flow. Er is geen
+  server-side sessie; de cookie is de gedeelde sleutel tussen website en RSVP.
+- **Unlock-endpoint** `POST /public/weddings/{slug}/rsvp/unlock` — valideert de passcode
+  en zet de cookie. Blijft ongewijzigd en wordt hergebruikt vanuit de website-gate.
+
+## Gedrag: poort volgt automatisch uit de flow-opzet
+
+| Flow-situatie | Website | Events getoond |
+|---|---|---|
+| Geen flows | Publiek (ongewijzigd) | Alle events |
+| Eén open flow (geen passcode) | Publiek | Gefilterd op die flow |
+| Passcode-flows | **Code vereist vóór content** | Gefilterd op de ontgrendelde flow |
+
+Er is dus **geen aparte toggle**: de poort staat aan zodra de bruiloft passcode-flows heeft.
+
+## Backend
+
+### 1. Website-endpoint wordt flow-aware
+
+`GET /w/{slug}` (`GetPublicWebsiteEndpoint.cs`) injecteert `IDataProtectionProvider` en
+haalt de flowId uit de cookie via `RsvpFlowCookie.ResolveFlowId`. Nieuwe respons-DTO:
+
+```csharp
+public class PublicWebsiteStateDto
+{
+    public bool RequiresPasscode { get; set; }
+    public PublicWeddingWebsiteDto? Website { get; set; } // null wanneer vergrendeld
+}
+```
+
+Nieuwe service-signatuur:
+`GetPublicBySlugAsync(string slug, Guid? unlockedFlowId)` in `WeddingWebsiteService`.
+
+Logica:
+1. Website ophalen (`GetPublishedBySlugAsync`); niet gevonden → `NotFound` (ongewijzigd).
+2. Flows van de wedding ophalen.
+   - **Geen flows** → `{ RequiresPasscode = false, Website = <ongefilterd> }` (huidig gedrag).
+   - **Open flow** → `{ RequiresPasscode = false, Website = <events gefilterd op open flow> }`.
+   - **Passcode-flows** en `unlockedFlowId` is null of hoort niet bij deze wedding →
+     `{ RequiresPasscode = true, Website = null }`. Content wordt niet geserialiseerd → geen lek.
+   - **Passcode-flows** met geldige `unlockedFlowId` binnen de wedding →
+     `{ RequiresPasscode = false, Website = <events gefilterd op die flow> }`.
+3. **Event-filtering**: waar nu ongefilterd `GetByWeddingIdForPublicAsync` wordt getoond
+   (events-sectie enabled), worden de events beperkt tot `flow.EventIds` van de relevante flow.
+
+### 2. RSVP vult de code niet opnieuw
+
+`GetRsvpFlowStateEndpoint.cs` resolvet óók de cookie en geeft `unlockedFlowId` door aan
+`GetFlowStateAsync(string weddingSlugOrId, Guid? unlockedFlowId)`. Is die geldig en hoort
+bij de wedding → bouw de flow direct (`RequiresPasscode = false, Flow = dto`), net als bij
+een open flow. Een unlock via de website telt zo meteen voor de RSVP.
+
+## Frontend
+
+- **`usePublicWebsiteState`** — hook die de nieuwe state-respons ophaalt.
+- **`WebsiteUnlockGate`** — component met code-invoer; hergebruikt `useUnlockRsvpFlow`.
+- **`PublicWebsitePage`** — toont bij `requiresPasscode` de gate i.p.v. de template. Na
+  geslaagde unlock: query invalideren en de site herladen (cookie zit er dan).
+- **`RsvpPage`** — geen wijziging nodig: als er via de site al is ontgrendeld, geeft de
+  flowstate nu direct het formulier terug.
+- i18n: nieuwe strings voor de gate in NL/EN/FR (`website.json`).
+
+## Edge cases
+
+- Cookie verlopen/ongeldig → `ResolveFlowId` geeft `null` → poort verschijnt opnieuw.
+- Cookie van flow A maar hoort bij wedding B → genegeerd (wedding-binding gecheckt) → poort dicht.
+- Events verwijderd na unlock → bestaande filtering op geldige event-ids vangt dit.
+- Ongepubliceerde site met flows → `/w/{slug}` geeft `NotFound` zoals nu (gate niet relevant).
+
+## Tests (xUnit + Moq)
+
+`WeddingWebsiteServiceTests`:
+- `GetPublicBySlugAsync` geen flows → website ongefilterd, `RequiresPasscode=false`.
+- open flow → events gefilterd op open flow, `RequiresPasscode=false`.
+- passcode-flows + geen/ongeldige/andere-wedding flowId → `RequiresPasscode=true`, `Website=null`.
+- passcode-flows + geldige flowId → events gefilterd op die flow, `RequiresPasscode=false`.
+
+`RsvpServiceTests`:
+- `GetFlowStateAsync` met geldige `unlockedFlowId` → directe flow, `RequiresPasscode=false`.
+- met ongeldige/andere-wedding flowId → `RequiresPasscode=true`.
+
+## Buiten scope
+
+`EventToDto` neemt momenteel `GuestDtos` mee op de publieke website — een bestaand
+privacy-punt, los van deze feature. Wordt apart afgehandeld.

--- a/docs/superpowers/specs/2026-07-01-website-access-code-design.md
+++ b/docs/superpowers/specs/2026-07-01-website-access-code-design.md
@@ -101,7 +101,10 @@ een open flow. Een unlock via de website telt zo meteen voor de RSVP.
 - `GetFlowStateAsync` met geldige `unlockedFlowId` → directe flow, `RequiresPasscode=false`.
 - met ongeldige/andere-wedding flowId → `RequiresPasscode=true`.
 
-## Buiten scope
+## Privacy-fix (meegenomen)
 
-`EventToDto` neemt momenteel `GuestDtos` mee op de publieke website — een bestaand
-privacy-punt, los van deze feature. Wordt apart afgehandeld.
+`EventToDto` nam `GuestDtos` mee op de publieke website (`GET /w/{slug}`) — een anoniem
+endpoint. Dat lekte per event de volledige gastenlijst (naam, achternaam, e-mail,
+dieetwensen, RSVP-status) in de JSON-respons. `BuildPublicWebsiteDtoAsync` leegt nu
+`GuestDtos` voor elk publiek event; test `GetPublicBySlugAsync_NeverExposesGuestList`
+dekt dit af. De publieke templates gebruiken enkel naam/datum/locatie/beschrijving.


### PR DESCRIPTION
## Wat & waarom
Koppels willen dat gasten eerst een code invullen vóór de trouwwebsite zichtbaar wordt, met gepersonaliseerde content (welke events ze uitgenodigd zijn), en zonder de code nóg eens op de RSVP te vragen.

De bestaande RSVP-passcode wordt hiervoor opgetild tot een poort voor de hele gepubliceerde website. De reeds bestaande gesigneerde `rsvp_flow`-cookie is de gedeelde sleutel tussen website en RSVP.

## Gedrag (volgt automatisch uit de flow-opzet)
- **Passcode-flows** → hele website achter de code; `GET /w/{slug}` geeft `{ requiresPasscode: true, website: null }` zonder geldige cookie (geen content-lek).
- **Open flow / geen flows** → site publiek zoals voorheen.
- Met geldige cookie of open flow worden de **events-sectie én de RSVP gefilterd op de flow** (`flow.EventIds`).
- De RSVP-flowstate leest dezelfde cookie → de code wordt niet opnieuw gevraagd.

## Wijzigingen
- Nieuw `PublicWebsiteStateDto`; `GetPublicBySlugAsync(slug, unlockedFlowId)` en `GetPublicWebsiteEndpoint` cookie-aware.
- `GetFlowStateAsync(slug, unlockedFlowId)` + `GetRsvpFlowStateEndpoint` lezen de cookie.
- **Privacy-fix:** `GET /w/{slug}` lekte via `EventToDto` de volledige gastenlijst (naam, e-mail, dieet, RSVP-status) op een anoniem endpoint. Publieke events bevatten nu geen gastgegevens meer.

## Tests
242/242 groen, incl. nieuwe tests voor de gate (met/zonder/andere-wedding cookie), event-filtering per flow, en `GetPublicBySlugAsync_NeverExposesGuestList`.

Spec: `docs/superpowers/specs/2026-07-01-website-access-code-design.md`

> Frontend-kant in aparte PR op `amare-wedding-frontend`.