### PR TITLE
fix: geen voorgevulde ceremony/reception in default website-content

### DIFF
--- a/WeddingManager.Application/Services/WeddingWebsiteService.cs
+++ b/WeddingManager.Application/Services/WeddingWebsiteService.cs
@@ -214,8 +214,8 @@ public class WeddingWebsiteService(
                     enabled = true,
                     title = "Ceremony",
                     venue = "",
-                    address = wedding.Location,
-                    date = wedding.Date.ToString("o"),
+                    address = "",
+                    date = "",
                     description = "",
                     mapUrl = ""
                 },
@@ -225,7 +225,7 @@ public class WeddingWebsiteService(
                     title = "Reception",
                     venue = "",
                     address = "",
-                    date = wedding.Date.ToString("o"),
+                    date = "",
                     description = "",
                     mapUrl = ""
                 }


### PR DESCRIPTION
## Probleem
Een nieuw aangemaakte website toonde meteen half-ingevulde **Ceremony**- en **Reception**-kaarten: ceremony met het bruiloftsadres en beide met de bruiloftsdatum (bv. "02:00"). Naast de Schedule-events oogde dat als dubbele/ruis-content.

## Oorzaak
`GetDefaultContent` vulde standaard voor:
- `ceremony.address = wedding.Location`, `ceremony.date = wedding.Date`
- `reception.date = wedding.Date`

Die velden horen bij de "Use Custom Details"-flow en moeten leeg starten zodat het koppel ze zélf invult.

## Fix
Ceremony/reception starten nu met lege `address`/`date` (net als `venue`/`description`/`mapUrl`). `enabled` blijft `true` zodat ze in de custom-details editor verschijnen om in te vullen.

Raakt alleen **nieuwe** websites (bestaande content in de DB blijft ongewijzigd).

## Tests
235/235 groen; geen test verwachtte de oude voorinvulling.

Samen met de frontend-fix (`amare-wedding-frontend#12`) verdwijnt de dubbele/lege "Wedding Details"-sectie in MinimalArchitecture.